### PR TITLE
PDF Parser: Non standard fonts fix

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,7 +40,8 @@ include_HEADERS = libs/json.hpp \
 				libs/pdf_parser.h \
 				libs/pdf_parser_helper.h \
 				libs/pdf.h \
-				libs/pdf_object.h
+				libs/pdf_object.h \
+				libs/pdf_font.h
 
 
 lib_YARA = /usr/local/lib
@@ -57,7 +58,8 @@ yextend_SOURCES = libs/json.hpp \
 				libs/pdf_parser.cpp \
 				libs/pdf_parser_helper.cpp \
 				libs/pdf.cpp \
-				libs/pdf_object.cpp
+				libs/pdf_object.cpp \
+				libs/pdf_font.cpp
 
 
 unittests:

--- a/libs/pdf.cpp
+++ b/libs/pdf.cpp
@@ -1,33 +1,18 @@
-/*****************************************************************************
+/*
  *
- * YEXTEND: Help for YARA users.
- * This file is part of yextend.
- *
- * Copyright (c) 2014-2018, Bayshore Networks, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- * the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- * following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
+ *  Created on: Nov 29, 2017
+ *      Author: rodrigo
+ */
 
+/* Include order
+Own .h.
+C.
+C++.
+Other libraries' .h files.
+Your project's .h files.
+*/
 #include "pdf.h"
+
 #include <cstring>
 
 #include <algorithm>
@@ -47,146 +32,250 @@
 
 namespace pdfparser {
 
-    extern "C" {
+extern "C" {
 
-        Pdf::Pdf(const uint8_t* buffer, size_t size) {
-	        start_pdf = buffer;
-	        length_pdf = size;
+Pdf::Pdf(const uint8_t* buffer, size_t size){
+	start_pdf = buffer;
+	length_pdf = size;
 
-	        auto current_obj_pointer = buffer;
-	        auto current_obj_size = size;
+	auto current_obj_pointer = buffer;
+	auto current_obj_size = size;
 
-	        while (current_obj_size > 0 && current_obj_size != std::string::npos) {
-		        PdfObject pdf_object{current_obj_pointer, current_obj_size};
+	while (current_obj_size > 0 && current_obj_size != std::string::npos){
+		PdfObject pdf_object{current_obj_pointer, current_obj_size};
 
-		        auto id = pdf_object.GetId();
-		        objects.emplace(id, pdf_object);
+		auto id = pdf_object.GetId();
+		//objects.insert(make_pair(id, pdf_object));
 
-		        BuildObjReference(pdf_object.GetDictionary()); //	Build objects reference library
+		if (id != "") { // for xref and so it is not recognized as pdf object
+			objects.emplace(id, pdf_object);
+			BuildObjReference(pdf_object.GetDictionary()); //	Build objects reference library
+		}
 
-		        current_obj_size = current_obj_size - (pdf_object.GetObjectEnd() - current_obj_pointer);
-		        current_obj_pointer = pdf_object.GetObjectEnd();
-	        }
-        }
+		current_obj_size = current_obj_size - (pdf_object.GetObjectEnd() - current_obj_pointer);
+		current_obj_pointer = pdf_object.GetObjectEnd();
+	}
+}
 
-        Pdf::~Pdf() {
-	        for (auto obj: objects) {
-		        Dictionary* dictionary = obj.second.GetDictionary();
-		        if (dictionary->dictionaries.size() > 0)
-			        DeleteDictionary(dictionary);
-	        }
-        }
 
-        void Pdf::DeleteDictionary(Dictionary* dictionary) {
-	        for (auto x: dictionary->dictionaries) {
-		        DeleteDictionary(x.second);
-		        delete x.second;
-	        }
-        }
+Pdf::~Pdf() {
+	for (auto obj: objects){
+		Dictionary* dictionary = obj.second.GetDictionary();
+		if (dictionary->dictionaries.size() > 0)
+			DeleteDictionary(dictionary);
+	}
+}
 
-        void Pdf::GetXref() {
-	        //  It can point to a plain xref object or to a streamed xref object
-	        xref_offset = FindStringInBufferReverse(start_pdf, "startxref", length_pdf); // TODO Verify
 
-	        if(memcmp (start_pdf+xref_offset, "xref", 4)){
-		        ;} //TODO
-        }
+void Pdf::DeleteDictionary(Dictionary* dictionary){
+	for (auto x: dictionary->dictionaries) {
+		DeleteDictionary(x.second);
+		delete x.second;
+	}
+}
 
-        void Pdf::BuildObjReference(Dictionary* dictionary) {
-	        const std::string kObjRefRegEx = "^[0-9]+[[:space:]]+[0-9]+"; // for indirect object reference '0 5 R'
-	        const std::regex obj_ref_regex {kObjRefRegEx};
-	        std::smatch sm;
 
-	        // Values
-	        for (auto x: dictionary->values) {
-		        std::regex_search (x.second, sm, obj_ref_regex);
-		        if (sm.size() > 0) {
-			        obj_ref[x.second] = x.first;
-		        }
-	        }
-	        // Dictionaries
-	        for (auto x: dictionary->dictionaries) {
-		        BuildObjReference(x.second);
+void Pdf::GetXref(){
+	//  It can point to a plain xref object or to a streamed xref object
+	xref_offset = FindStringInBufferReverse(start_pdf, "startxref", length_pdf); // TODO Verify
 
-	        }
-        }
+	if(memcmp (start_pdf+xref_offset, "xref", 4)){
+		;} //TODO
+}
 
-        std::vector<uint8_t> Pdf::ExtractText() {
-	        auto accepted = kFilterDictionary;
-	        auto rejected_attributes = kNonTextAttributes;
-	        auto rejected_dictionary = kNonTextDictionary;
 
-	        std::vector<uint8_t> text_buffer{};
-	        auto whole_text = text_buffer;
+void Pdf::BuildObjReference(Dictionary* dictionary){
+	const std::regex obj_ref_regex {Pdf::kObjectReferenceRegEx};
+	std::smatch sm;
 
-	        for (auto map_obj: objects) {
-		        auto id = map_obj.first;
-		        auto obj = map_obj.second;
-	            auto flag = obj_ref[id];
+	// Values
+	for (auto x: dictionary->values) {
+		std::regex_search (x.second, sm, obj_ref_regex);
+		if (sm.size() > 0) {
+			obj_ref[x.second] = x.first;
+		}
+	}
+	// Dictionaries
+	for (auto x: dictionary->dictionaries) {
+		BuildObjReference(x.second);
 
-	            bool in_rejected_dict{false};
-	            for (auto key: obj.GetDictionary()->values) {
-	            	if (rejected_dictionary.end() != std::find(rejected_dictionary.begin(),
-	            			rejected_dictionary.end(), key.first)) {
-	            		in_rejected_dict = true;
-	            		break;
-	            	}
-	            }
+	}
+}
 
-		        if (obj.HasStream() && !in_rejected_dict &&
-			        ((accepted.end() != std::find(accepted.begin(), accepted.end(), flag)) || //It is in accepted or
-			        (rejected_attributes.end() == std::find(rejected_attributes.begin(), rejected_attributes.end(), flag)))) { //it is not in rejected then process
+void Pdf::BuildFonts(){
 
-			        if (obj.ExtractStream((obj.GetDictionary())->values["Filter"])){
-				        obj.TextParser();
-        				text_buffer = obj.GetParsedText();
-				        whole_text.insert(whole_text.end(), text_buffer.begin(), text_buffer.end());
-			        }
-		        }
-	        }
+	const std::regex obj_ref_regex {Pdf::kObjectReferenceRegEx};
+	std::smatch sm;
 
-	        return whole_text;
-        }
+	//bool font_found{false};
 
-        std::vector<std::vector<uint8_t>> Pdf::ExtractFile() { //TODO
-	        auto accepted = kFileFlag;
-	        auto rejected_attributes = kNonFileAttributes;
-	        auto rejected_dictionary = kNonFileDictionary;
+	// Objects are sweep sequentially because a font definition
+	// can be a indirect reference or embedded data as a dictionary as a value of /Font
+	for (auto object_map: objects) {
+		auto object = object_map.second;
+		auto dictionary = object.GetDictionary();
 
-	        std::vector<std::vector<uint8_t>> all_files {};
+#ifdef DEBUG
+		if (object.GetId() == "4 0") {
+			std::cout << "DEBUG\n";
+		}
+		std::cout << "Pdf::BuildFonts Obj id: " << object.GetId() << '\n';
+#endif
 
-	        for (auto map_obj: objects) {
-		        auto id = map_obj.first;
-		        auto obj = map_obj.second;
-	            auto flag = obj_ref[id];
+		// Detect /Font key in dictionary
+		// The result can be a indirect reference "65 0" or a dictionary in string format "<</F1 5 0>
+		auto font_definition = object.ExtractFontDefinition(dictionary);
 
-	            bool in_rejected_dict{false};
-	            for (auto key: obj.GetDictionary()->values) { // Todo verify object 66
-	            	if (rejected_dictionary.end() != std::find(rejected_dictionary.begin(),
-	            			rejected_dictionary.end(), key.second)) {
-	            		in_rejected_dict = true;
-	            		break;
-	            	}
-	            }
+		// Font found
+		if (font_definition.size() > 0) {
+			Dictionary* font_dictionary;
+			bool new_dictionary{false};
 
-		        if (obj.HasStream() && !in_rejected_dict &&
-			        ((accepted.end() != std::find(accepted.begin(), accepted.end(), flag)) || //It is in accepted or
-			        (rejected_attributes.end() == std::find(rejected_attributes.begin(), rejected_attributes.end(), flag)))) { //it is not in rejected then process
+			// font_definition is an indirect reference
+			if (font_definition.substr(0, kDictionaryBegin.size()) != kDictionaryBegin) {
+				font_dictionary = objects.find(font_definition)->second.GetDictionary();
+			}
 
-			        if (obj.ExtractStream((obj.GetDictionary())->values["Filter"])) {
-				        auto temp = obj.GetDecodedStream();
-				        all_files.push_back(obj.GetDecodedStream());
-			        }
-		        }
-	        }
+			// It is an embedded dictionary TESTME
+			else {
+				new_dictionary = true;
+				font_dictionary = new Dictionary{};
+				auto font_begin = reinterpret_cast<const uint8_t*>(&font_definition[0]);
+				object.UnfoldDictionary(font_dictionary, font_begin, font_begin+font_definition.size());
+			}
 
-	        return all_files;
-        }
+			// Creates fonts
+			for (auto font_it = font_dictionary->values.begin(); font_it != font_dictionary->values.end(); ++font_it){
 
-        size_t Pdf::Size(){
-	        return objects.size();
+				auto font_id = font_it->first;
+				Font font{font_id};
+
+				auto font_object = objects[font_it->second];
+
+				auto to_unicode_reference = font_object.GetDictionary()->values[kToUnicode];
+
+				// It has /ToUnicode
+				if (to_unicode_reference != "") {
+					auto unicode = objects[to_unicode_reference];
+
+					// TODO multiple filters in cascade
+					auto filter = unicode.GetDictionary()->values[kFilterTagBegin];
+
+					unicode.ExtractStream(filter);
+					auto bytes_cmap = unicode.GetDecodedStream();
+					std::string cmap(bytes_cmap.begin(), bytes_cmap.end());
+					font.BuildUnicodeMap(cmap);
+				}
+
+				fonts[font_id] = font;
+			}
+
+			// If a new dictionary for font reference '/F1 5 0 R' was needed, destroy it
+			if (new_dictionary) {
+				delete (font_dictionary);
+			}
+		}
+	}
+}
+
+
+std::vector<uint8_t> Pdf::ExtractText(TextEncoding encoding){
+	auto accepted = kFilterDictionary;
+	auto rejected_attributes = kNonTextAttributes;
+	auto rejected_dictionary = kNonTextDictionary;
+
+	// BuildFonts is executed once Pdf::ExtractText is called (has no sense to execute it in advance
+	// and when all objects are in memory to be sure of having all objects referred indirectly
+	Pdf::BuildFonts();
+
+	std::vector<uint8_t> text_buffer{};
+	auto whole_text = text_buffer;
+
+	for (auto map_obj: objects) {
+		auto id = map_obj.first;
+		auto obj = map_obj.second;
+	    auto flag = obj_ref[id];
+
+	    bool in_rejected_dict{false};
+	    for (auto key: obj.GetDictionary()->values) {
+	    	if (rejected_dictionary.end() != std::find(rejected_dictionary.begin(),
+	    			rejected_dictionary.end(), key.first)) {
+	    		in_rejected_dict = true;
+	    		break;
+	    	}
 	    }
 
-    } // !extern "C"
+		if (obj.HasStream() && !in_rejected_dict &&
+			((accepted.end() != std::find(accepted.begin(), accepted.end(), flag)) || //It is in accepted or
+			(rejected_attributes.end() == std::find(rejected_attributes.begin(), rejected_attributes.end(), flag)))) { //it is not in rejected then process
+
+			if (obj.ExtractStream((obj.GetDictionary())->values[kFilterTagBegin])){
+
+				obj.ParseText(fonts);
+				text_buffer = obj.GetParsedPlainText(encoding);
+				whole_text.insert(whole_text.end(), text_buffer.begin(), text_buffer.end());
+			}
+
+		}
+	}
+	return whole_text;
+}
+
+
+std::vector<std::vector<uint8_t>> Pdf::ExtractFile(){ //TODO
+	auto accepted_keys = kFileAcceptedKeys;
+	auto rejected_attributes = kNonFileAttributes;
+	auto rejected_dictionary = kNonFileDictionary;
+
+	std::vector<uint8_t> file_buffer{};
+	std::vector<std::vector<uint8_t>> all_files {};
+
+	for (auto map_obj: objects) {
+
+		auto id = map_obj.first;
+		auto obj = map_obj.second;
+	    auto flag = obj_ref[id];
+
+	    bool is_rejected_dict{false};
+	    bool is_accepted_keys{false};
+	    for (auto key: obj.GetDictionary()->values) { // Todo verify object 66
+	    	if (rejected_dictionary.end() != std::find(rejected_dictionary.begin(),
+	    			rejected_dictionary.end(), key.second)) {
+	    		is_rejected_dict = true;
+	    		break;
+	    	}
+	    	if (accepted_keys.end() != std::find(accepted_keys.begin(), accepted_keys.end(), key.first)) {
+	    		is_accepted_keys = true;
+	    		break;
+	    	}
+	    }
+
+	    bool is_rejected_attributes =
+	    		rejected_attributes.end() != std::find(rejected_attributes.begin(), rejected_attributes.end(), flag);
+
+	    //  Has stream AND not in rejected dictionary AND not in rejected attribute AND
+	    // (accepted attribures OR flag is not empty)
+	    // not in rejected attributes)
+	    if (obj.HasStream() && !is_rejected_dict && !is_rejected_attributes &&
+	    		(is_accepted_keys || (flag != ""))) {
+
+	    	if (obj.ExtractStream((obj.GetDictionary())->values[kFilterTagBegin])) {
+				auto temp = obj.GetDecodedStream();
+				all_files.push_back(obj.GetDecodedStream());
+			}
+		}
+	}
+
+	return all_files;
+}
+
+
+size_t Pdf::Size(){
+	return objects.size();
+	}
+
+
+} // !extern "C"
 
 } // !namespace pdfparser
+

--- a/libs/pdf.h
+++ b/libs/pdf.h
@@ -1,31 +1,8 @@
-/*****************************************************************************
+/*
  *
- * YEXTEND: Help for YARA users.
- * This file is part of yextend.
- *
- * Copyright (c) 2014-2018, Bayshore Networks, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- * the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- * following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
+ *  Created on: Nov 29, 2017
+ *      Author: rodrigo
+ */
 
 #ifndef PDF_H_
 #define PDF_H_
@@ -37,38 +14,55 @@
 #include <map>
 #include <vector>
 
+#include "pdf_font.h"
 #include "pdf_object.h"
+#include "pdf_text_encoding.h"
 
 namespace pdfparser {
 
-    extern "C" {
+extern "C" {
 
-        class Pdf {
-	        size_t xref_offset{0}; // Offset to start of xref from start_pdf
-	        std::vector<size_t> xref{}; // Offset of each 'obj' in pdf
 
-	        const uint8_t* start_pdf{nullptr};
-	        size_t length_pdf{0};
 
-	        std::map<std::string, PdfObject> objects{};
+class Pdf {
+	const std::string kObjectReferenceRegEx = "^[0-9]+[[:space:]]+[0-9]+"; // for indirect object reference '0 5 R'
 
-	        std::map<std::string, std::string> obj_ref;
+	size_t xref_offset{0}; // Offset to start of xref from start_pdf
+	std::vector<size_t> xref{}; // Offset of each 'obj' in pdf
 
-	        void BuildObjReference(Dictionary* dictionary);
-	        void DeleteDictionary(Dictionary* dictionary);
-            void GetXref();
+	const uint8_t* start_pdf{nullptr};
+	size_t length_pdf{0};
 
-        public:
-	        Pdf(const uint8_t* buffer, size_t size);
-	        ~Pdf();
+	std::unordered_map<std::string, PdfObject> 	objects{};
+	std::map<std::string, std::string> 			obj_ref{}; // Map of objects that are the indirect reference for certain dictionary key (
+	std::map<std::string, pdfparser::Font>		fonts{}; // Key: Font ID. Value: Font
 
-	        size_t Size();
-	        std::vector<uint8_t> ExtractText();
-	        std::vector<std::vector<uint8_t>> ExtractFile();
-        };
+	void GetXref();
+	void BuildObjReference(Dictionary* dictionary);
 
-    } // !extern "C"
+	/**
+	 * @brief Build the needed Font objects and fill the class attribute fonts.
+	 *
+	 */
+	void BuildFonts(void);
+	void DeleteDictionary(Dictionary* dictionary);
+
+public:
+	Pdf(const uint8_t* buffer, size_t size);
+	~Pdf();
+
+	size_t Size();
+	std::vector<uint8_t> ExtractText(TextEncoding encoding);
+	std::vector<std::vector<uint8_t>> ExtractFile();
+};
+
+
+
+
+
+} // !extern "C"
 
 } // !namespace pdfparser
+
 
 #endif /* PDF_H_ */

--- a/libs/pdf_font.cpp
+++ b/libs/pdf_font.cpp
@@ -1,0 +1,104 @@
+/*
+ *
+ *  Created on: Feb 16, 2018
+ *      Author: rodrigo
+ */
+
+/* Include order
+Own .h.
+C.
+C++.
+Other libraries' .h files.
+Your project's .h files.
+*/
+//#include <stdint.h>
+
+#include "pdf_font.h"
+
+#include <iostream>
+#include <iterator>
+#include <regex>
+#include <string>
+
+
+namespace pdfparser {
+
+extern "C" {
+Font::Font (){};
+
+Font::Font (std::string id) {
+	this->id = id;
+}
+
+
+void Font::BuildUnicodeMap(std::string raw_cidfont) {
+	const std::regex cid_unicode_re {R"(^<([[:xdigit:]]{2})>\s*<([[:xdigit:]]+)>\s*([\s\S]*))"};
+	const std::string cid_ordering = kCmapOrdering+R"(\s*\(([[:w:]]+)\))";
+	const std::regex cid_ordering_re {cid_ordering};// TODO regex for ordering
+	std::smatch sm;
+
+	// Looks up /Ordering to get endianess
+	auto begin = raw_cidfont.find(kCmapBegin) + kCmapBegin.size();
+	begin = raw_cidfont.find(kCmapOrdering, begin);
+	auto last_part = raw_cidfont.substr(begin, std::string::npos);
+
+	std::regex_search (last_part, sm, cid_ordering_re);
+	encoding = sm.str(1);
+
+	// Looks up encoded chars
+	begin = last_part.find(kBeginBFChar, begin) + kBeginBFChar.size();
+	begin = last_part.find(kBeginHex, begin);
+
+	auto end = last_part.find(kEndBFChar, begin);
+	last_part = last_part.substr(begin, end-begin);
+
+	std::regex_search (last_part, sm, cid_unicode_re);
+	auto cmap_elem = sm.size();
+
+	while (cmap_elem >= 3) {
+
+		#ifdef DEBUG
+		//std::cout << "Elements of sm: "<< cmap_elem << std::endl;
+		std::cout << "Element 1(cid): " << sm.str(1) << std::endl;
+		std::cout << "Element 2(unicode): " << sm.str(2) << std::endl;
+		//std::cout << "Last elem(rest): " << sm.str(cmap_elem-1) << std::endl;
+		#endif
+
+		std::string cid = sm.str(1); // It is the cid of cid-value pair
+		std::string unicode_str = sm.str(2);
+		last_part = sm.str(cmap_elem-1);
+
+		// Orders bytes according little endian or big endian
+		/*
+		for (auto it = unicode_str.begin(); it != unicode_str.end(); it+=4) {
+			Utf16ToByte input;
+			std::string utf16(it, it+4); // 4 hexa numbers
+			input.utf16 = stoi(utf16, nullptr, 16);
+			unicode_map[cid].insert(unicode_map[cid].end(), input.byte, input.byte+2);
+		}
+		*/
+
+		// Stores encoding as is
+		for (auto it = unicode_str.begin(); it != unicode_str.end(); it+=2) {
+			std::string utf16(it, it+2); // 2 hexa numbers
+			unicode_map[cid].push_back(stoi(utf16, nullptr, 16));
+		}
+
+		std::regex_search (last_part, sm, cid_unicode_re);
+		cmap_elem = sm.size();
+	}
+}
+
+
+UNICODE_MAP Font::GetUnicodeMap() {
+	return unicode_map;
+}
+
+
+const char* Font::GetFontEndianess() {
+	return kOrdering.at(encoding).c_str();
+}
+
+} // !extern "C"
+
+} // !namespace pdfparser

--- a/libs/pdf_font.h
+++ b/libs/pdf_font.h
@@ -1,0 +1,73 @@
+/*
+ *
+ *  Created on: Feb 16, 2018
+ *      Author: rodrigo
+ */
+
+#ifndef FONT_H_
+#define FONT_H_
+
+//#define DEBUG
+
+/* Include order
+Own .h.
+C.
+C++.
+Other libraries' .h files.
+Your project's .h files.
+*/
+
+#include <cstddef>
+#include <string>
+#include <map>
+#include <vector>
+
+namespace pdfparser {
+
+extern "C" {
+
+using UNICODE_MAP=std::map<std::string, std::vector<uint8_t>>;
+//typedef std::map<std::string, std::string> UNICODE_MAP;
+
+const std::string kCmapBegin			{"begincmap"};
+const std::string kCmapOrdering			{"/Ordering"};
+const std::string kCodeSpaceRangeBegin 	{"begincodespacerange"};
+const std::string kBeginBFChar			{"beginbfchar"};
+const std::string kEndBFChar			{"endbfchar"};
+const std::string kBeginHex				{"<"};
+
+
+const std::map<std::string, const std::string> kOrdering = {
+		{"None", "UTF-8"},
+		{"UCS", "UTF-16BE"}
+};
+
+
+class Font {
+	union Utf16ToByte {
+		uint8_t byte[2];
+		char16_t utf16;
+	};
+	std::string id{};
+	std::string base_font{"None"};
+	std::string encoding {"None"};
+	UNICODE_MAP unicode_map{}; // Key: cid, value: Unicode
+
+public:
+	Font();
+	Font(std::string id);
+
+	/**
+	 * @brief					Parses the unicode map and fills up unicode_map
+	 * @param raw_definition	string with raw CIDFont
+	 */
+	void BuildUnicodeMap(std::string raw_cidfont);
+	UNICODE_MAP GetUnicodeMap();
+	const char * GetFontEndianess();
+};
+
+} // !extern "C"
+
+} // !namespace pdfparser
+
+#endif /* FONTS_H_ */

--- a/libs/pdf_object.cpp
+++ b/libs/pdf_object.cpp
@@ -1,33 +1,19 @@
-/*****************************************************************************
+/*
  *
- * YEXTEND: Help for YARA users.
- * This file is part of yextend.
- *
- * Copyright (c) 2014-2018, Bayshore Networks, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- * the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- * following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
- 
+ *  Created on: Nov 29, 2017
+ *      Author: rodrigo
+ */
+
+/* Include order
+Own .h.
+C.
+C++.
+Other libraries' .h files.
+Your project's .h files.
+*/
 #include "pdf_object.h"
+
+#include <iconv.h>
 
 #include <cstring>
 
@@ -44,447 +30,892 @@
 
 #include <zlib.h>
 
+#include "pdf_font.h"
 #include "pdf_parser_helper.h"
+#include "pdf_text_encoding.h"
+
 
 namespace pdfparser {
-    extern "C" {
-
-        /**
-         * @brief Gets the first pdf object contained in buffer
-         * @param buffer pointer to pdf
-         * @param size size of buffer
-         */
-        PdfObject::PdfObject(const uint8_t* buffer, size_t size){
-
-	        const std::string kObjRegEx = "([0-9]+[[:space:]]+[0-9]+)[[:space:]]+"+kObjBegin+"[[:space:]]+"; // reg_exp.g. '10 0 obj'
-
-	        std::string string_buffer(buffer, buffer+size);
-	        std::regex regexp {kObjRegEx};
-	        std::smatch sm;
-	        std::regex_search (string_buffer, sm, regexp); // Searchs for the begining of an object, reg_exp.g. '10 0 obj'
-
-	        #ifdef DEBUG
-	            std::cout << sm.position(0) << std::endl;
-	            std::cout << sm.str(0) << std::endl;
-	        #endif
-
-	        if (sm.size() > 0) {
-		        auto obj_start = sm.position(0);
-		        auto obj_end = string_buffer.find(kObjEnd);
-		        auto obj_header_size = sm[0].length();
-
-		        id = sm[1];
-
-		        pdf_object = buffer + obj_start;
-		        object_size = obj_end-obj_start;
-		        auto next_item = pdf_object + obj_header_size;
-
-		        if (string_buffer.substr(obj_start + obj_header_size, kDictionaryBegin.size()) == "<<") { //It has a dictionary
-
-			        DictionaryBoundaries dict_boundaries = GetDictionaryBoundaries(pdf_object + obj_header_size,
-					        pdf_object + object_size);
-			        dictionary_start	= dict_boundaries.start;
-			        dictionary_end 		= dict_boundaries.end;
-
-			        UnfoldDictionary(&dictionary, dictionary_start, dictionary_end);
-
-			        GetFilters();
-			        GetStream();
-		        }
-	        }
-	        // There is no more 'obj'
-	        else {
-		        object_size = 0;
-		        pdf_object = buffer + size;
-	        }
-        }
-
-        PdfObject::~PdfObject() {
-	        delete[] decoded_stream;
-        }
-
-        std::string PdfObject::GetId() {
-	        return id;
-        }
-
-        Dictionary* PdfObject::GetDictionary() {
-	        return &dictionary;
-        }
-
-        void  PdfObject::UnfoldDictionary(Dictionary* dictionary, const uint8_t* begin, const uint8_t* end) {
-	        size_t dictionary_index{0};
-
-	        const std::string kKeyRegEx = "([[:w:]-]+)([[:s:]])*(.*)"; // reg_exp.g. '/Key'
-	        const std::string kObjRefRegEx = "^([0-9]+[[:space:]]+[0-9]+)([[:space:]]+R[[:space:]]*)(.*)"; // for indirect object reference '0 5 R'
-	        const std::string kArrayRegEx = "^(\\[.*\\])(.*)";													// for arrays '[zzz yyy]'
-	        const std::string kLiteralRegEx = "^(\\(.*\\))(.*)";													// for literals '(this is a literal)'
-
-
-	        const std::regex key_regex {kKeyRegEx};
-	        const std::regex obj_ref_regex {kObjRefRegEx};
-	        const std::regex array_regex {kArrayRegEx};
-	        const std::regex literal_regex{kLiteralRegEx};
-
-	        std::string last_part(begin, end);				//Dictionary splitted in key and rest
-	        std::string key{};								// Key of dictionary
-
-	        std::smatch sm;
-	        std::regex_search (last_part, sm, key_regex); // Searchs for the begining of an object, reg_exp.g. '10 0 obj'
-	        auto directory_elem = sm.size();
-
-	        while (directory_elem > 1) {
-		        #ifdef DEBUG
-		            std::cout << sm.size() << std::endl;
-		            std::cout << sm.str(0) << std::endl;
-		            std::cout << sm.str(1) << std::endl;
-		            std::cout << sm.str(directory_elem-1) << std::endl;
-		        #endif
-
-		        key = sm.str(1);
-		        last_part = sm.str(directory_elem-1);
-		        dictionary_index = dictionary_index + sm.position(directory_elem-1);
-
-		        // It is a key-dictionary pair
-		        if (last_part.substr(0, kDictionaryBegin.size()) == kDictionaryBegin) { // Contains a dictionary as value
-			        auto dict_bound = GetDictionaryBoundaries(begin + dictionary_index, end);
-			        Dictionary* new_dict = new Dictionary;
-			        UnfoldDictionary(new_dict, dict_bound.start, dict_bound.end);
-			        dictionary->dictionaries[key] = new_dict;
-
-			        dictionary_index = dictionary_index + dict_bound.end - dict_bound.start;
-			        last_part = last_part.substr(dict_bound.end - dict_bound.start, std::string::npos);
-		        } else { // It is a key-value pair
-			        std::smatch sm_key;
-			        std::smatch sm_array;
-			        std::smatch sm_literal;
-			        std::smatch sm_obj_ref;
-
-			        std::regex_search (last_part, sm_key, key_regex);
-			        std::regex_search (last_part, sm_array, array_regex);
-			        std::regex_search (last_part, sm_literal, literal_regex);
-			        std::regex_search (last_part, sm_obj_ref, obj_ref_regex);
-
-			        if (sm_obj_ref.size() > 0) {
-				        sm = sm_obj_ref;
-			        } else if (sm_array.size() > 0) {
-				        sm = sm_array;
-			        } else if (sm_literal.size() > 0) {
-				        sm = sm_literal;
-			        } else if (sm_key.size() > 0){
-				        sm = sm_key;
-			        }
-
-			        directory_elem = sm.size();
-
-			        dictionary->values[key] = sm.str(1);
-
-			        last_part = sm.str(directory_elem-1);
-			        dictionary_index = dictionary_index + sm.position(directory_elem-1);
-		        }
-
-		        std::regex_search (last_part, sm, key_regex);
-		        directory_elem = sm.size();
-	        }
-        }
-
-        void PdfObject::GetFilters() {
-	        const char kDelimiter {'/'};
-
-	        size_t filter_start = FindStringInBuffer (pdf_object, kFilterTagBegin.c_str(), object_size); //Begin of 'Filter' object
-
-	        if (filter_start != std::string::npos) {
-		        filter_start = filter_start + kFilterTagBegin.length();
-		        size_t filter_size = FindStringInBuffer (pdf_object + filter_start, kFilterTagEnd.c_str(), object_size - filter_start);
-
-		        if (filter_size != std::string::npos) {
-			        dictionary_end = pdf_object + filter_start + filter_size;
-
-			        std::string line{(char*)pdf_object, filter_start, filter_size};
-			        auto filters = SplitString(line, kDelimiter);
-
-			        for (size_t i = 0; i<filters.size(); i++) {
-				        if (kFilterDictionary.end() != std::find(kFilterDictionary.begin(), kFilterDictionary.end(), filters[i])) {
-					        this->filters.push_back(filters[i]);
-				        }
-			        }
-		        }
-	        } else {
-		        dictionary_end = pdf_object; // No filter found
-	        }
-        }
-
-        void PdfObject::GetStream() {
-
-	        size_t stream_position = FindStringInBuffer (dictionary_end, kStreamBegin.c_str(), object_size - (dictionary_end - pdf_object)); //Begin of 'stream'
-
-	        if (stream_position != std::string::npos) {
-		        stream_position = stream_position + kStreamBegin.length();
-		        auto stream_buffer = dictionary_end + stream_position;
-
-		        // To comply with 7.3.8.1 of ISO 32000:2008 and get exactly the start of stream to decode
-		        bool correct_syntax = false;
-		        if (memcmp (stream_buffer, kPdfEol1, 1) == 0) {
-			        stream_buffer++;
-			        correct_syntax = true;
-		        } else if (memcmp (stream_buffer, kPdfEol2, 2) == 0) {
-			        stream_buffer = stream_buffer+2;
-			        correct_syntax = true;
-		        }
-
-		        if (correct_syntax) {
-			        size_t stream_size = FindStringInBuffer (stream_buffer, kStreamEnd.c_str(), object_size - (stream_buffer - pdf_object));
-
-			        if (stream_size != std::string::npos) {
-				        // To comply with 7.3.8.1 of ISO 32000:2008 and get exactly the end of stream to decode
-				        correct_syntax = false;
-				        if (memcmp (stream_buffer + stream_size - 2, kPdfEol2, 2) == 0) {
-					        stream_size=stream_size-2;
-					        correct_syntax = true;
-				        } else if (memcmp (stream_buffer + stream_size - 1, kPdfEol1, 1) == 0){
-					        stream_size--;
-					        correct_syntax = true;
-				        }
-
-				        if (correct_syntax){
-					        stream_start = stream_buffer; // TODO Verify value
-					        this->stream_size = stream_size;
-					        stream_end = stream_start + stream_size;
-				        }
-			        }
-		        }
-	        }
-        }
-
-        bool PdfObject::HasStream(){
-            return (stream_size > 0);
-        }
-
-        bool PdfObject::ExtractStream(std::string filter){
-	        #ifdef DEBUG
-    	        std::cout << "applied filter:\n" << filter << std::endl; //Debug
-	        #endif
-
-	        if (filter == "") {
-		        std::vector<uint8_t> temp (stream_start, stream_end);
-		        decoded_stream_vector = temp;
-		        return true;
-	        } else if ((filter.compare("LZWDecode") != 0) || (filter.compare("FlateDecode") != 0)) {
-		        FlateLZWDecode();
-		        return true;
-	        } else {
-		        #ifdef DEBUG
-		        std::cout << "No accepted filter" << std::endl;
-		        #endif
-
-		        decoded_stream_vector = {};
-		        return false;
-	        }
-        }
-
-        void PdfObject::FlateLZWDecode() {
-	        #ifdef DEBUG
-    	        std::cout << "Deflating..." << std::endl; // Debug
-	        #endif
-
-	        size_t outsize = (stream_size)*DEFLATE_BUFFER_MULTIPLIER;
-	        decoded_stream = new uint8_t [outsize]{'\0'};
-
-	        //Now use zlib to inflate. Must be initialized to '\0'
-	        z_stream zstrm{};
-
-	        zstrm.avail_in = stream_size + 1;
-	        zstrm.avail_out = outsize;
-	        zstrm.next_in = (Bytef*)(stream_start);
-	        zstrm.next_out = (Bytef*)decoded_stream;
-
-	        #ifdef DEBUG
-    	        std::cout << "Deflating...2" << std::endl; // DEBUG
-	        #endif
-
-	        int rsti = inflateInit(&zstrm);
-
-	        #ifdef DEBUG
-    	        std::cout << "Deflating...3" << std::endl; // DEBUG
-	        #endif
-
-	        if (rsti == Z_OK) {
-		        #ifdef DEBUG
-    		        std::cout << "Z_OK" << std::endl;
-		        #endif
-
-		        int rst2 = inflate (&zstrm, Z_FINISH);
-
-		        #ifdef DEBUG
-		        std::cout << "rst2 = " << rsti << std::endl;
-		        #endif
-
-		        if (rst2 >= 0) {
-			        //Ok, got something, extract the content:
-			        decoded_stream_size = zstrm.total_out;
-
-			        decoded_stream_vector.assign(decoded_stream, decoded_stream+decoded_stream_size);
-			        #ifdef DEBUG
-			        std::cout << id <<" DECODED content:\n" << decoded_stream << std::endl; // DEBUG
-			        #endif
-		        }
-	        } else {
-		        std::cout << "Z_NOK" << std::endl;
-	        }
-        }
-
-        std::vector<uint8_t> PdfObject::GetDecodedStream(){
-	        return decoded_stream_vector;
-        }
-
-        /**
-         * Extract text from plain stream.
-         *
-         * Uses the decoded_stream as input and puts its result in parsed_text.
-         */
-        void PdfObject::TextParser() { //TODO unbalanced parentesis (escaped chars) and Hexadecimal strings
-	        bool in_text_block = false;		// Indicates when the position is inside a BT/ET block
-	        size_t parenthesis_depth = 0;	// Indicates when the position is inside a block delimited by '(' and ')' (a literal) and its depth
-	        bool escaped_char = false;		// Indicates when the following character is escaped
-
-	        uint8_t buffer[EXTRACT_TEXT_BUFFER_SIZE]{'\0'};
-	        std::string octal_char{};
-
-	        for (size_t i=0; i < decoded_stream_size; i++) {
-		        uint8_t current_char = decoded_stream[i];
-
-		        // Rotate the buffer and stores the previous characters to detect BT and ET
-		        buffer[0] = buffer[1];
-		        buffer[1] = current_char;
-
-		        // If not in BT/ET check if it is a start of BT/ET (000)->(100) [in_text_block, parentesis_depth, escaped]
-		        if (!in_text_block && (memcmp(buffer, TEXT_BLOCK_START, 2) == 0)) {
-			        in_text_block = true;
-                } else if (in_text_block) {
-			        if (parenthesis_depth == 0) {
-				        // Start of literal '(' (100)->(110)
-				        if (current_char == '(') {
-					        parenthesis_depth++;
-				        } else if (memcmp(buffer, TEXT_BLOCK_END, 2) == 0) { // End of BT/ET (100)->(000)
-					        in_text_block = false;
-				        }
-			        } else if (parenthesis_depth > 0) { // Already inside a literal (110) or (111)
-				        if (escaped_char && octal_char.empty()) {
-					        if (isdigit(current_char)) {
-						        octal_char.push_back(current_char);
-					        } else {
-						        escaped_char = false;
-
-						        if (current_char == 'n') {
-							        parsed_text.push_back('\n');}
-
-						        else if (current_char == 'r') {
-							        parsed_text.push_back('\r');}
-
-						        else if (current_char == 't') {
-							        parsed_text.push_back('\t');}
-
-						        else if (current_char == 'b'){
-							        parsed_text.push_back('\b');}
-
-						        else if (current_char == 'f'){
-							        parsed_text.push_back('\f');}
-
-						        else if (current_char == '\\'){
-							        parsed_text.push_back('\\');}
-
-						        else if (current_char == '('){
-							        parsed_text.push_back('(');}
-
-						        else if (current_char == ')'){
-							        parsed_text.push_back(')');}
-					        }
-				        } else {
-					        // Escaped and octal
-					        if (!octal_char.empty()) {
-						        if (octal_char.size() == 3 || !isdigit(current_char)) {
-							        escaped_char = false;
-							        uint8_t actual_char = static_cast<uint8_t>(std::stoi(octal_char));
-							        parsed_text.push_back(actual_char);
-							        octal_char.erase();
-						        } else {
-							        octal_char.push_back(current_char);
-						        }
-					        }
-
-					        // Not escaped
-					        if (!escaped_char) {
-						        if (current_char == '\\') {
-							        escaped_char = true;
-						        } else {
-							        if (current_char == '(') {
-								        parenthesis_depth++;
-							        } else if (current_char == ')') {
-								        parenthesis_depth--;
-							        }
-
-							        if (parenthesis_depth > 0) {
-								        parsed_text.push_back(current_char);
-							        }
-						        }
-					        }
-				        }
-			        }
-		        }
-	        }
-
-	        #ifdef DEBUG
-	            std::string output(parsed_text.begin(), parsed_text.end()); // DEBUG
-	            std::cout << "output:\n" << output << std::endl << std::flush; // DEBUG
-	        #endif
-        }
-
-        std::vector<uint8_t> PdfObject::GetParsedText(){
-        	return parsed_text;
-        }
-
-        //start of 'obj' + size of 'obj' + length of flag
-        const uint8_t* PdfObject::GetObjectEnd() {
-	        if (object_size == 0) {
-		        return pdf_object;
-	        } else {
-		        return pdf_object + object_size + kObjEnd.length();
-	        }
-        }
-
-        /**
-         * @brief	Detects the limits of the outer dictionary between the limits provided
-         * @param begin
-         * @param end
-         */
-        DictionaryBoundaries PdfObject::GetDictionaryBoundaries (const uint8_t* begin, const uint8_t* end) {
-	        std::string string_buffer(begin, end);
-
-	        auto dict_begin = string_buffer.find(kDictionaryBegin);
-	        DictionaryBoundaries dict_bound{};
-	        dict_bound.start =  begin + dict_begin;
-
-	        size_t last_dictionary_position{dict_begin+kDictionaryBegin.size()};	// Two chars '<<' as the first dictionary begin
-	        size_t dictionaries_counter{1};								// It has at least 1 dictionary
-	        auto dictionaries_quantity = dictionaries_counter;			// Dictionary blocks present
-	        auto dictionary_size = end - begin;							// Not necessarily the dictionary itself, but a limit to search
-
-	        while ((last_dictionary_position < dictionary_size) && (dictionaries_counter > 0)) {
-		        if (string_buffer.substr(dict_begin + last_dictionary_position, kDictionaryBegin.size()) == kDictionaryBegin) {
-			        last_dictionary_position = last_dictionary_position + 2;
-			        ++dictionaries_counter;
-			        ++dictionaries_quantity;
-		        } else if (string_buffer.substr(dict_begin + last_dictionary_position, kDictionaryEnd.size()) == kDictionaryEnd) {
-			        last_dictionary_position = last_dictionary_position + 2;
-			        --dictionaries_counter;
-		        } else {
-			        ++last_dictionary_position;
-		        }
-	        }
-	        dict_bound.end = begin + last_dictionary_position;
-
-	        return dict_bound;
-        }
-
-    } // !extern "C"
+
+
+extern "C" {
+
+
+PdfObject::PdfObject() {
+
+}
+
+
+/**
+ * @brief Gets the first pdf object contained in buffer
+ * @param buffer pointer to pdf
+ * @param size size of buffer
+ */
+PdfObject::PdfObject(const uint8_t* buffer, size_t size){
+
+	const std::string kObjRegEx = "([0-9]+[[:space:]]+[0-9]+)[[:space:]]+"+kObjBegin+"[[:space:]]+"; // reg_exp.g. '10 0 obj'
+
+	std::string string_buffer(buffer, buffer+size);
+	std::regex regexp {kObjRegEx};
+	std::smatch sm;
+	std::regex_search (string_buffer, sm, regexp); // Searchs for the begining of an object, reg_exp.g. '10 0 obj'
+
+	#ifdef DEBUG
+	std::cout << sm.position(0) << std::endl; // Debug
+	std::cout << sm.str(0) << std::endl; // Debug
+	#endif
+
+	if (sm.size() > 0) {
+	//size_t obj_start = FindStringInBuffer (buffer, kObjStart.c_str(), size); //Begin of 'obj' object
+	//if (obj_start != std::string::npos){
+		auto obj_start = sm.position(0);
+		auto obj_end = string_buffer.find(kObjEnd);
+		auto obj_header_size = sm[0].length();
+
+		id = sm[1];
+
+		pdf_object = buffer + obj_start;
+		object_size = obj_end-obj_start;
+		auto next_item = pdf_object + obj_header_size;
+
+		if (string_buffer.substr(obj_start + obj_header_size, kDictionaryBegin.size()) == "<<") { //It has a dictionary
+
+			DictionaryBoundaries dict_boundaries = GetDictionaryBoundaries(pdf_object + obj_header_size,
+					pdf_object + object_size);
+			dictionary_start	= dict_boundaries.start;
+			dictionary_end 		= dict_boundaries.end;
+
+			UnfoldDictionary(&dictionary, dictionary_start, dictionary_end);
+			GetFilters();
+			GetStream();
+		}
+	}
+	// There is no more 'obj'
+	else {
+		object_size = 0;
+		pdf_object = buffer + size;
+	}
+}
+
+
+PdfObject::~PdfObject(){
+	delete[] decoded_stream;
+//	if (dictionary.dictionaries.size() > 0)
+//		DeleteDictionary(&dictionary);
+}
+
+
+/*
+void PdfObject::DeleteDictionary(Dictionary* dictionary){
+	for (auto x: dictionary->dictionaries) {
+		DeleteDictionary(x.second);
+		delete x.second;
+	}
+}
+*/
+
+
+std::string PdfObject::GetId() {
+	return id;
+}
+
+
+Dictionary* PdfObject::GetDictionary() {
+	return &dictionary;
+}
+
+
+void  PdfObject::UnfoldDictionary(Dictionary* dictionary, const uint8_t* begin, const uint8_t* end) { //TODO
+
+	auto dictionary_begin = begin+kDictionaryBegin.size();
+
+	size_t dictionary_index{0};
+
+	//const std::string kObjectBegin = R("^([0-9]+\s+[0-9]+\s+obj)(\s*)([\s\S]*))"; // Obj '15 0 obj'
+	//const std::string kNameRegEx 	= R"(^(/[^\x00-\x20\(\)\<\>\[\]\{\}/\%\x7f-\xff]+)(\s*)([\s\S]*))";	// Name objects /Key1+3 Optimal TODO
+	const std::string kBoolRegEx	= R"(^(true|false)\s*([\s\S]*))";				// Boolean true or false
+	const std::string kNameRegEx 	= R"(^(/[[:w:]\+\-]+)\s*([\s\S]*))";			// Name objects /Key1+3
+	const std::string kObjRefRegEx 	= R"(^([0-9]+\s+[0-9]+)\s+R\s*([\s\S]*))";		// Indirect object reference '0 5 R'
+	// V0 const std::string kArrayRegEx 	= R"(^(\[.*\])([\s\S]*))";				// Arrays '[zzz yyy]'
+	const std::string kArrayRegEx 	= R"(^(\[[[:alnum:]\+\-/\R\s]+\])\s*([\s\S]*))";// Arrays '[zzz yyy]'
+	const std::string kLiteralRegEx = R"(^(\(.*\))\s*([\s\S]*))";					// Literals '(this is a literal)'
+	const std::string kLiteralHexRegEx = R"(^(<[[:xdigit:]]+>)\s*([\s\S]*))";		// Literals in hexa '<FEFF0054>'
+	const std::string kNumberRegEx	= R"(^([\+-]?[0-9]*\.?[0-9]*)\s*([\s\S]*))";	// Numbers 33 +33 -33 0.4 .4 +0.4 +.4
+
+	const std::regex bool_regex {kBoolRegEx};
+	const std::regex name_regex {kNameRegEx};
+	const std::regex obj_ref_regex {kObjRefRegEx};
+	const std::regex array_regex {kArrayRegEx};
+	const std::regex literal_regex {kLiteralRegEx};
+	const std::regex literal_hex_regex {kLiteralHexRegEx};
+	const std::regex number_regex {kNumberRegEx};
+
+	std::string last_part(dictionary_begin, end);	//Dictionary splitted in key and rest
+
+	std::smatch sm;
+	std::regex_search (last_part, sm, name_regex); // Searches for the beginning of an key /key
+	auto directory_elem = sm.size();
+
+	while (directory_elem > 1) {
+
+		std::string key = sm.str(1); // It is the key of key-value pair
+		last_part = sm.str(directory_elem-1);
+		dictionary_index = dictionary_index + sm.position(directory_elem-1); //to the next char after key
+
+#ifdef DEBUG
+		if ((id == "4 0" && true) || (id == "1 0" && false)) {
+			std::cout << "DEBUG" << std::endl;
+		}
+		std::cout << "\nPDF Object: " << id << ". Elements of sm: "<< directory_elem << std::endl;
+		//std::cout << "Element 0: " << sm.str(0) << std::endl; // All matches
+		std::cout << "Key: " << key << std::endl;
+		//std::cout << "Last elem(rest): " << sm.str(directory_elem-1) << std::endl;
+#endif
+
+		// It is a key-dictionary pair
+		if (last_part.substr(0, kDictionaryBegin.size()) == kDictionaryBegin) { // Contains a dictionary as value
+			auto dict_bound = GetDictionaryBoundaries(dictionary_begin + dictionary_index, end);
+			Dictionary* new_dict = new Dictionary;
+			UnfoldDictionary(new_dict, dict_bound.start, dict_bound.end);
+			dictionary->dictionaries[key] = new_dict;
+
+			dictionary_index = dictionary_index + dict_bound.end - dict_bound.start;
+
+			// Advances to the next key
+			auto next_key = last_part.find(kNameTagBegin, dict_bound.end - dict_bound.start);
+			if (next_key < std::string::npos) {
+				// There is still dictionary
+				last_part = last_part.substr(next_key, std::string::npos);
+			}
+			else{
+				//No more dictionary to search in
+				last_part = "";
+			}
+		}
+		// It is a key-value pair
+		else {
+			std::smatch sm_bool;
+			std::smatch sm_name;
+			std::smatch sm_array;
+			std::smatch sm_literal;
+			std::smatch sm_literal_hex;
+			std::smatch sm_obj_ref;
+			std::smatch sm_number;
+
+			std::regex_search (last_part, sm_bool, bool_regex);
+			std::regex_search (last_part, sm_name, name_regex);
+			std::regex_search (last_part, sm_array, array_regex);
+			std::regex_search (last_part, sm_literal, literal_regex);
+			std::regex_search (last_part, sm_literal_hex, literal_hex_regex);
+			std::regex_search (last_part, sm_obj_ref, obj_ref_regex);
+			std::regex_search (last_part, sm_number, number_regex);
+
+			if (sm_bool.size() > 0) {
+				sm = sm_bool;
+			}
+			else if (sm_obj_ref.size() > 0) {
+				sm = sm_obj_ref;
+			}
+			else if (sm_array.size() > 0) {
+				sm = sm_array;
+			}
+			else if (sm_literal.size() > 0) {
+				sm = sm_literal;
+			}
+			else if (sm_literal_hex.size() > 0) {
+				sm = sm_literal_hex;
+			}
+			else if (sm_name.size() > 0) {
+				sm = sm_name;
+			}
+			else if (sm_number.size() > 0) {
+				sm = sm_number;
+			}
+
+			directory_elem = sm.size();
+
+#ifdef DEBUG
+			//std::cout << "String: " << last_part << std::endl;
+			//std::cout << "Elements of sm: "<< directory_elem << std::endl;
+			//std::cout << "Element 0: " << sm.str(0) << std::endl; // All matches
+			std::cout << "Element 1: " << sm.str(1) << std::endl;
+			//std::cout << "Last elem(rest): " << sm.str(directory_elem-1) << std::endl;
+#endif
+
+			auto value = sm.str(1);
+			std::replace(value.begin(), value.end(), '\n', ' '); // Replace \n by space
+			dictionary->values[key] = value;
+
+			last_part = sm.str(directory_elem-1);
+			dictionary_index = dictionary_index + sm.position(directory_elem-1);
+		}
+		std::regex_search (last_part, sm, name_regex);
+		directory_elem = sm.size();
+	}
+}
+
+
+void PdfObject::GetFilters() {
+	const char kDelimiter {'/'};
+
+	// It has filters
+	if (dictionary.values.find(kFilterTagBegin) != dictionary.values.end()) {
+		auto filters_buffer = dictionary.values[kFilterTagBegin];
+
+		// If it is an array TODO verify the case of array
+		if (filters_buffer.substr(0, kArrayTagBegin.size()) == kArrayTagBegin) {
+			auto filters_array = SplitString(filters_buffer, kDelimiter);
+
+			//filters.insert(filters.end(), filters_array.begin(), filters_array.end());
+			for (auto x: filters_array) {
+				filters.push_back(kDelimiter+x);
+			}
+		}
+
+		// It is not an array -> single value
+		else {
+			filters.push_back(filters_buffer);
+		}
+	}
+
+	// No filter found
+
+	/*
+	const char kDelimiter {'/'};
+
+	size_t filter_start = FindStringInBuffer (pdf_object, kFilterTagBegin.c_str(), object_size); //Begin of 'Filter' object
+
+	if (filter_start != std::string::npos){
+		filter_start = filter_start + kFilterTagBegin.length();
+		size_t filter_size = FindStringInBuffer (pdf_object + filter_start, kFilterTagEnd.c_str(), object_size - filter_start);
+
+		if (filter_size != std::string::npos){
+			dictionary_end = pdf_object + filter_start + filter_size;
+
+			std::string line{(char*)pdf_object, filter_start, filter_size};
+			auto filters = SplitString(line, kDelimiter);
+
+			for (size_t i = 0; i<filters.size(); i++) {
+				if (kFilterDictionary.end() != std::find(kFilterDictionary.begin(), kFilterDictionary.end(), filters[i])) {
+					this->filters.push_back(filters[i]);
+				}
+			}
+		}
+	}
+	else {
+		dictionary_end = pdf_object; // No filter found
+	}
+	*/
+}
+
+
+void PdfObject::GetStream(){
+
+	size_t stream_position = FindStringInBuffer (dictionary_end, kStreamBegin.c_str(), object_size - (dictionary_end - pdf_object)); //Begin of 'stream'
+	
+	if (stream_position != std::string::npos){
+		stream_position = stream_position + kStreamBegin.length();
+		auto stream_buffer = dictionary_end + stream_position;
+
+		// To comply with 7.3.8.1 of ISO 32000:2008 and get exactly the start of stream to decode
+		bool correct_syntax = false;
+		if (memcmp (stream_buffer, kPdfEol1, 1) == 0) {
+			stream_buffer++;
+			correct_syntax = true;
+		}
+		else if (memcmp (stream_buffer, kPdfEol2, 2) == 0){
+			stream_buffer = stream_buffer+2;
+			correct_syntax = true;
+		}
+
+		if (correct_syntax){
+			size_t stream_size = FindStringInBuffer (stream_buffer, kStreamEnd.c_str(), object_size - (stream_buffer - pdf_object));
+
+			if (stream_size != std::string::npos){
+				// To comply with 7.3.8.1 of ISO 32000:2008 and get exactly the end of stream to decode
+				correct_syntax = false;
+				if (memcmp (stream_buffer + stream_size - 2, kPdfEol2, 2) == 0) {
+					stream_size=stream_size-2;
+					correct_syntax = true;
+				}
+				else if (memcmp (stream_buffer + stream_size - 1, kPdfEol1, 1) == 0){
+					stream_size--;
+					correct_syntax = true;
+				}
+
+				if (correct_syntax){
+					stream_start = stream_buffer; // TODO Verify value
+					this->stream_size = stream_size;
+					stream_end = stream_start + stream_size;
+				}
+			}
+		}
+	}
+}
+
+
+bool PdfObject::HasStream(){
+	if (stream_size > 0) return true;
+	else return false;
+}
+
+
+bool PdfObject::ExtractStream(std::string filter){
+
+#ifdef DEBUG
+	std::cout << "\n### DEBUG PdFObject::ExtractStream ###\nApplied filter: " << filter << std::endl; //Debug
+#endif
+
+	// It has no filter, so the stream is no encoded
+	if (filter == "") {
+		std::vector<uint8_t> temp (stream_start, stream_end);
+		decoded_stream_vector = temp;
+		return true;
+	}
+	else if ((filter.compare("LZWDecode") != 0) || (filter.compare("FlateDecode") != 0)) {
+		FlateLZWDecode();
+		return true;
+	}
+	else {
+		#ifdef DEBUG
+		std::cout << "No accepted filter" << std::endl;
+		#endif
+
+		decoded_stream_vector = {};
+		return false;
+	}
+}
+
+
+void PdfObject::FlateLZWDecode() {
+
+#ifdef DEBUG
+	std::cout << "\n### DEBUG PdfObject::FlateLZWDecode ###\n" << std::endl; // Debug
+#endif
+
+	size_t outsize = (stream_size)*DEFLATE_BUFFER_MULTIPLIER;
+	decoded_stream = new uint8_t [outsize]{'\0'};
+
+	//Now use zlib to inflate. Must be initialized to '\0'
+	z_stream zstrm{};
+
+	zstrm.avail_in = stream_size + 1;
+	zstrm.avail_out = outsize;
+	zstrm.next_in = (Bytef*)(stream_start);
+	zstrm.next_out = (Bytef*)decoded_stream;
+
+	int rsti = inflateInit(&zstrm);
+
+	if (rsti == Z_OK)
+	{
+		int rst2 = inflate (&zstrm, Z_FINISH);
+
+		if (rst2 >= 0)
+		{
+			//Ok, got something, extract the content:
+			decoded_stream_size = zstrm.total_out;
+			decoded_stream_vector.assign(decoded_stream, decoded_stream+decoded_stream_size);
+
+#ifdef DEBUG
+			std::cout << "Obj: " << id <<" Deflating Ok. DECODED content:\n" << decoded_stream << std::endl;
+#endif
+		}
+	}
+	else {
+#ifdef DEBUG
+		std::cout << "Z_NOK" << std::endl;
+#endif
+	}
+}
+
+
+std::vector<uint8_t> PdfObject::GetDecodedStream(){
+	return decoded_stream_vector;
+}
+
+
+/**
+ * Extract text from plain stream.
+ *
+ * Uses the decoded_stream as input and puts its result in parsed_plain_text.
+ */
+//TODO Hexadecimal strings
+void PdfObject::ParseText(std::map<std::string, Font>& fonts){
+
+	bool in_text_block = false;			// Indicates when the position is inside a BT/ET block
+	size_t parenthesis_depth = 0;		// Indicates when the position is inside a block delimited by '(' and ')' (a literal) and its depth. It shall be printed with Tj
+	size_t square_brackets_depth = 0;	// Indicates when the position is inside a array. It shall be printed with TJ
+	bool escaped_char = false;			// Indicates when the following character is escaped
+
+	uint8_t current_char{'\0'};
+	uint8_t buffer[EXTRACT_TEXT_BUFFER_SIZE]{'\0'};
+
+	std::string octal_char{};
+	std::string text_buffer{};	// Stores temporally the text to be parsed later on
+	std::string local_font{};	// Local font in BT/ET
+
+	size_t decoded_stream_idx=0;
+	while (decoded_stream_idx < decoded_stream_size) {
+		current_char = decoded_stream[decoded_stream_idx++];
+
+		// Rotate the buffer and stores the previous characters to detect BT and ET
+		for (unsigned char j=0; j<EXTRACT_TEXT_BUFFER_SIZE-1; ++j) {
+			buffer[j] = buffer[j+1];
+		}
+		buffer[EXTRACT_TEXT_BUFFER_SIZE-1] = current_char;
+		std::string buffer_str (buffer, buffer+EXTRACT_TEXT_BUFFER_SIZE);
+
+		// If not in BT/ET check if it is a start of BT/ET (000)->(100) [in_text_block, parentesis_depth, escaped]
+		if (!in_text_block && (memcmp(buffer, TEXT_BLOCK_START, 2) == 0)) {
+			in_text_block = true;}
+
+		// Inside BT/ET block
+		else if (in_text_block) {
+
+			if (parenthesis_depth == 0 && square_brackets_depth == 0) {
+
+				// Font selector
+				if (memcmp(buffer, TEXT_FONT, 2) == 0){
+					local_font = TEXT_FONT;
+
+					auto from = reinterpret_cast<const char *>(&decoded_stream[decoded_stream_idx]);
+					auto to = from + TEXT_FONT_MAX_SIZE;
+
+					std::string font_buffer(from, to);
+
+					// Searchs for the name of the font
+					const std::regex re {R"(^([[:w:]]+)\s)"};
+					std::smatch sm;
+					std::regex_search (font_buffer, sm, re);
+					local_font += sm.str(1);
+
+					// ATTN idx is also incremented here. Buffer becomes corrupted with no impact in parsing
+					decoded_stream_idx += sm.str(1).size();
+				}
+
+				// TJ received, array buffer has info then parse text array. Nomultilevel arrays allowed
+				else if ((memcmp(buffer, TEXT_PRINT_ARRAY, 2) == 0) && (text_buffer.size() > 0)){
+					auto font = fonts[local_font];
+					ParseTextArray(text_buffer, font);
+					text_buffer.clear();
+				}
+
+				// Operator resets array and literal buffer
+				else if (std::find(kTextResetingOperators.begin(), kTextResetingOperators.end(), buffer_str)
+				!= kTextResetingOperators.end()) {
+					text_buffer.clear();
+				}
+
+				// Start of literal '(' (100)->(110)
+				else if (current_char == '(') {
+					++parenthesis_depth;
+				}
+
+				else if (current_char == '[') {
+					++square_brackets_depth;
+				}
+
+				// End of BT/ET (100)->(000)
+				else if (memcmp(buffer, TEXT_BLOCK_END, 2) == 0){
+					in_text_block = false;
+					local_font.clear();
+					text_buffer.clear();
+				}
+			}
+
+			// Inside of an array
+			else if (square_brackets_depth > 0) {
+				if (current_char == ']') {
+					--square_brackets_depth;
+				}
+				else if (current_char == '[') {
+					++square_brackets_depth;
+				}
+				else text_buffer += current_char;
+			}
+
+			//  Already inside a literal (110) or (111). TODO reshape with parenthesis parser.
+			else if (parenthesis_depth > 0){
+
+				if (escaped_char && octal_char.empty()) {
+					if (isdigit(current_char)){
+						octal_char.push_back(current_char);
+					}
+
+					else {
+						escaped_char = false;
+
+						if (current_char == 'n') {
+							parsed_plain_text.push_back('\n');}
+
+						else if (current_char == 'r') {
+							parsed_plain_text.push_back('\r');}
+
+						else if (current_char == 't') {
+							parsed_plain_text.push_back('\t');}
+
+						else if (current_char == 'b'){
+							parsed_plain_text.push_back('\b');}
+
+						else if (current_char == 'f'){
+							parsed_plain_text.push_back('\f');}
+
+						else if (current_char == '\\'){
+							parsed_plain_text.push_back('\\');}
+
+						else if (current_char == '('){
+							parsed_plain_text.push_back('(');}
+
+						else if (current_char == ')'){
+							parsed_plain_text.push_back(')');}
+					}
+				}
+
+				else {
+					// Escaped and octal
+					if (!octal_char.empty()) {
+
+						if (octal_char.size() == 3 || !isdigit(current_char)) {
+							escaped_char = false;
+							uint8_t actual_char = static_cast<uint8_t>(std::stoi(octal_char));
+							parsed_plain_text.push_back(actual_char);
+							octal_char.erase();
+						}
+						else {
+							octal_char.push_back(current_char);
+						}
+					}
+
+					// Not escaped
+					if (!escaped_char){
+
+						if (current_char == '\\'){
+							escaped_char = true;
+						}
+
+						else {
+							if (current_char == '(') {
+								parenthesis_depth++;
+							}
+							else if (current_char == ')') {
+								parenthesis_depth--;
+							}
+
+							if (parenthesis_depth > 0) {
+								parsed_plain_text.push_back(current_char);
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+
+std::vector<uint8_t> PdfObject::GetParsedPlainText(TextEncoding encoding){
+	if (encoding == TextEncoding::utf8) {
+		std::vector<uint8_t> utf8_text(parsed_plain_text_utf8.begin(), parsed_plain_text_utf8.end());
+		return utf8_text;
+	}
+	else {
+		return parsed_plain_text;
+	}
+}
+
+/**
+ * @brief	 start of 'obj' + size of 'obj' + length of flag
+ * @return
+ */
+const uint8_t* PdfObject::GetObjectEnd() {
+	if (object_size == 0) {
+		return pdf_object;
+	}
+	else {
+		return pdf_object + object_size + kObjEnd.length();
+	}
+}
+
+
+/**
+ * @brief	Detects the limits of the outer dictionary between the limits provided
+ * @param begin
+ * @param end
+ */
+DictionaryBoundaries PdfObject::GetDictionaryBoundaries (const uint8_t* begin, const uint8_t* end) {
+
+	std::string string_buffer(begin, end);
+
+	auto dict_begin = string_buffer.find(kDictionaryBegin);
+	DictionaryBoundaries dict_bound{};
+	dict_bound.start =  begin + dict_begin;
+
+	size_t last_dictionary_position{dict_begin+kDictionaryBegin.size()}; // Advances chars quantity of '<<' as the first dictionary begin
+	size_t dictionaries_counter{1};						// Index of dictionaries. It is already inside the first
+	auto dictionary_size = end - begin;					// Not necessarily the dictionary itself, but a limit to search
+
+	// Sweeps dictionary counting inner dictionaries
+	while ((last_dictionary_position < dictionary_size) && (dictionaries_counter > 0)) {
+		if (string_buffer.substr(dict_begin + last_dictionary_position, kDictionaryBegin.size()) == kDictionaryBegin) {
+			last_dictionary_position += 2;
+			++dictionaries_counter;
+		}
+		else if (string_buffer.substr(dict_begin + last_dictionary_position, kDictionaryEnd.size()) == kDictionaryEnd) {
+			last_dictionary_position += 2;
+			--dictionaries_counter;
+		}
+		else {
+			++last_dictionary_position;
+		}
+	}
+	dict_bound.end = begin + last_dictionary_position;
+
+	return dict_bound;
+}
+
+
+std::string PdfObject::ExtractFontDefinition(Dictionary* dictionary) {
+	bool font_found{false};
+	std::string font_definition{""};
+
+	auto values = dictionary->values;
+
+	// check if the value is a indirect reference
+	if (values.find(kFontTagBegin) != values.end()) {
+		font_found = true;
+		font_definition = dictionary->values[kFontTagBegin];
+		}
+
+	// If not and there are dictionaries check them
+	else if (dictionary->dictionaries.size() != 0) {
+		auto subdictionary = dictionary->dictionaries; //map
+
+		// If the no dictionary key is not Font, analyze insider dictionaries
+		if (subdictionary.find(kFontTagBegin) == subdictionary.end()) {
+
+			auto subdictionary_iterator = subdictionary.begin();
+			while (!font_found && (subdictionary_iterator != subdictionary.end())) {
+
+				font_definition = ExtractFontDefinition(subdictionary_iterator->second); // pass the dictionary associated
+
+				if (font_definition.size() > 0) {
+					font_found = true;
+				}
+				else {
+					std::advance(subdictionary_iterator, 1);
+				}
+			}
+		}
+		else { // Font definition is stored in a dictionary
+			font_definition =  subdictionary[kFontTagBegin]->IndirectReference();
+		}
+	}
+
+	return font_definition;
+}
+
+
+void PdfObject::ParseTextArray(std::string& array, Font& font) {
+	//TESTME empty font
+	std::vector<uint8_t> parsing_buffer{};
+	auto unicode_map = font.GetUnicodeMap();
+
+	auto it = array.begin();
+	while (it != array.end()){
+
+		// Inside a hexadecimal char
+		if (*it == '<') {
+			bool is_hexa = true;
+
+			++it;
+			while (is_hexa && it != array.end()) {
+
+				if (*(it) == '>') {
+					is_hexa = false;
+					//++it;
+				}
+				else {
+					std::string cid(it, it+2);
+#ifdef DEBUG
+					if ((cid == "35") || (cid == "27") || (cid == "28")) {
+						//std::cout << "DEBUG\n";
+					}
+#endif
+					//parsed_plain_text.push_back(unicode_map[cid]); //TESTME empty map
+					parsing_buffer.insert(parsing_buffer.end(),
+							unicode_map[cid].begin(),
+							unicode_map[cid].end()); //TESTME empty map
+
+					it+=2;
+				}
+			}
+		}
+		//There is literal text inside the array
+		else if (*it == '(') {
+			// Detect end of literal
+
+			++it;
+			auto literal_it_end = it;
+			bool is_literal_end {false};
+			while (!is_literal_end && (literal_it_end != array.end())) {
+
+				// It's an escaped character, the following one shall be skipped (to be processed in TextParse)
+				// For example for the case of \(
+				if (*literal_it_end == '\\') {
+					literal_it_end +=2;
+				}
+				else if (*literal_it_end == ')') {
+						is_literal_end = true;
+				}
+				else {
+					++literal_it_end;
+				}
+			}
+			std::string literal_to_parse(it, literal_it_end);
+
+			auto literal_parsed = ParseTextLiteral(literal_to_parse);
+			parsing_buffer.insert(parsing_buffer.end(), literal_parsed.begin(), literal_parsed.end());
+
+			it = literal_it_end;
+		}
+
+		++it;
+	}
+
+	// Finished parsing. Convert to utf8 for displaying purpouses
+	size_t max_out_buffer = parsing_buffer.size() * 3 + 1;
+	std::vector<char> out_buffer(max_out_buffer);
+
+	iconv_t converter = iconv_open("UTF-8", font.GetFontEndianess());
+	auto from_ptr = reinterpret_cast<char *>(parsing_buffer.data());
+	auto to_ptr = out_buffer.data();
+	//char *to_ptr = &(out_buffer[0]);
+
+	size_t in_remaining_buffer = parsing_buffer.size();
+	size_t out_remaining_buffer = max_out_buffer;
+
+	iconv(converter, &from_ptr, &in_remaining_buffer, &to_ptr, &out_remaining_buffer);
+	auto out_buffer_used = max_out_buffer-out_remaining_buffer;
+
+	// Stores text in original format
+	parsed_plain_text.insert(parsed_plain_text.end(), parsing_buffer.begin(), parsing_buffer.end());
+
+	// Stores text in utf8
+	parsed_plain_text_utf8.append(&out_buffer[0], out_buffer_used);
+	iconv_close(converter);
+
+#ifdef DEBUG
+	std::cout << "\nParsed UTF-8 text\n " << parsed_plain_text_utf8.data() << '\n';
+	std::cout << "\nParsed raw text\n" << parsed_plain_text.data() << '\n';
+#endif
+
+	/*
+	std::wstring_convert<std::codecvt_utf8_utf16<char16_t>,char16_t> conversion;
+	std::u16string u16(parsed_plain_text.begin(), parsed_plain_text.end());
+	auto output1 = conversion.to_bytes(u16);
+*/
+}
+
+
+std::string PdfObject::ParseTextLiteral(std::string& text){
+
+	std::string parsed_literal{};
+	std::string octal_char{};
+
+	bool escaped_char = false;
+
+	auto it = text.begin();
+	while (it != text.end()) {
+
+		// Escaped and octal
+		if (escaped_char && octal_char.empty()) {
+
+			// It is an octal. Accumulate digits in octal buffer
+			if (isdigit(*it)){
+				octal_char.push_back(*it);
+			}
+
+			// It is an escaped char but not an octal
+			else {
+				escaped_char = false;
+
+				if (*it == 'n') {
+					parsed_literal.push_back('\n');}
+
+				else if (*it == 'r') {
+					parsed_literal.push_back('\r');}
+
+				else if (*it == 't') {
+					parsed_literal.push_back('\t');}
+
+				else if (*it == 'b'){
+					parsed_literal.push_back('\b');}
+
+				else if (*it == 'f'){
+					parsed_literal.push_back('\f');}
+
+				// *it == '\\' || *it == '(' *it == ')'
+				else {
+					parsed_literal.push_back(*it);
+				}
+			}
+		}
+
+		// Escaped or octal
+		else {
+			// Octal
+			if (!octal_char.empty()) {
+
+				if (octal_char.size() == 3 || !isdigit(*it)) {
+					escaped_char = false;
+					auto actual_char = static_cast<uint8_t>(std::stoi(octal_char));
+					parsed_literal.push_back(actual_char);
+					octal_char.erase();
+				}
+				else {
+					octal_char.push_back(*it);
+				}
+			}
+
+			// Not escaped
+			if (!escaped_char){
+
+				if (*it == '\\'){
+					escaped_char = true;
+				}
+				else {
+					parsed_literal.push_back(*it);
+				}
+			}
+		}
+
+		++it;
+	}
+	return parsed_literal;
+}
+
+
+/**
+ * @brief	Returns a dictionary in the form "<</key value>>" to be parsed elsewhere
+ * @return
+ */
+std::string Dictionary::IndirectReference() {
+	std::string buffer{kDictionaryBegin};
+
+	// TODO Manage many fonts in the same
+	for (auto value: values) {
+		buffer = buffer + value.first + " " + value.second + " R ";
+	}
+
+	// Eliminates the trailing space
+	buffer.resize(buffer.size()-1);
+	buffer.append(kDictionaryEnd);
+
+	return buffer;
+}
+
+
+} // !extern "C"
 
 } // !namespace pdfparser
+

--- a/libs/pdf_object.h
+++ b/libs/pdf_object.h
@@ -1,36 +1,12 @@
-/*****************************************************************************
+/*
+ * parser.h
  *
- * YEXTEND: Help for YARA users.
- * This file is part of yextend.
- *
- * Copyright (c) 2014-2018, Bayshore Networks, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- * the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- * following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
+ *  Created on: Nov 29, 2017
+ *      Author: rodrigo
+ */
 
-#ifndef PDF_OBJECT_H_
-#define PDF_OBJECT_H_
-
-//#define DEBUG
+#ifndef OBJECT_H_
+#define OBJECT_H_
 
 #include <stdint.h>
 
@@ -40,132 +16,187 @@
 #include <unordered_map>
 #include <vector>
 
+#include "pdf_font.h"
+#include "pdf_text_encoding.h"
+
+
 namespace pdfparser {
 
-    extern "C" {
+extern "C" {
 
-        #define DEFLATE_BUFFER_MULTIPLIER		10
-        #define EXTRACT_TEXT_BUFFER_SIZE		2
-        #define TEXT_BLOCK_START				"BT"
-        #define TEXT_BLOCK_END					"ET"
+#define DEFLATE_BUFFER_MULTIPLIER		10
+#define EXTRACT_TEXT_BUFFER_SIZE		2  //2 needed for BT and ET
+//#define EXTRACT_TEXT_OCTAL_BUFFER_SIZE	3
+#define TEXT_BLOCK_START				"BT"
+#define TEXT_BLOCK_END					"ET"
+#define TEXT_FONT						"/F"
+#define TEXT_FONT_MAX_SIZE				4	// including "/F"
+#define TEXT_PRINT_ARRAY				"TJ" // Command in BT/ET block to print array []
+#define TEXT_PRINT_LITERAL				"Tj" // Command in BT/ET block to print literal (). Also ' and " TODO
 
-        struct Dictionary {
-	        std::unordered_map<std::string, std::string> values;
-	        std::unordered_map<std::string, Dictionary*> dictionaries;
-        };
+const std::string kDictionaryBegin	{"<<"};
+const std::string kDictionaryEnd	{">>"};
 
-        struct DictionaryBoundaries {
-	        const uint8_t* start{nullptr};
-	        const uint8_t* end{nullptr};
-        };
+const std::string kToUnicode		{"/ToUnicode"};
+const std::string kFilterTagBegin	{"/Filter"}; // Flag of begin of 'Filter' section
 
-        const std::vector<std::string> kFilterDictionary {
-	        "ASCIIHexDecode",
-	        "ASCII85Decode",
-	        "LZWDecode",
-	        "FlateDecode",
-	        "RunLenghtDecode",
-	        "CCITTFaxDecode",
-	        "JBIG2Decode",
-	        "DCTDecode",
-	        "JPXDecode",
-	        "Crypt"
-        };
+struct Dictionary {
+	std::unordered_map<std::string, std::string> values; // Stores the key-value pairs of a certain dictionary
+	std::unordered_map<std::string, Dictionary*> dictionaries; // Stores the key-dictionary pairs of a certain dictionary
 
-        const std::vector<std::string> kTextDictionary { // BS-25. Dismiss no text stream objects (/Length1)
-	        "Contents"
-	    };
+	std::string IndirectReference();
+};
 
-        const std::vector<std::string> kNonTextDictionary { // BS-25. Dismiss no text stream objects (/Length1)
-	        "Length1",
-	        "Length2",
-	        "Length3",
-	        "DL",
-	        "EmbeddedFile"
-	    };
+struct DictionaryBoundaries {
+	const uint8_t* start{nullptr};
+	const uint8_t* end{nullptr};
+};
 
-        const std::vector<std::string> kNonTextAttributes { // BS-25. Dismiss no text stream objects (/Length1)
-	        "ToUnicode",
-	        "FontFile2"
-	    };
 
-        const std::vector<std::string> kFileFlag { // BS-26. Detach from PDF attachments specified as files.
-	        "DL",
-	        "EmbeddedFile"
-	    };
+const std::vector<std::string> kFilterDictionary{
+	"/ASCIIHexDecode",
+	"/ASCII85Decode",
+	"/LZWDecode",
+	"/FlateDecode",
+	"/RunLenghtDecode",
+	"/CCITTFaxDecode",
+	"/JBIG2Decode",
+	"/DCTDecode",
+	"/JPXDecode",
+	"/Crypt"};
 
-        const std::vector<std::string> kNonFileAttributes { // BS-26. Detach from PDF attachments specified as files.
-	        "Contents"
-	    };
+const std::vector<std::string> kTextDictionary{ // BS-25. Dismiss no text stream objects (/Length1)
+	"/Contents"
+	};
 
-        const std::vector<std::string> kNonFileDictionary { // BS-26. Detach from PDF attachments specified as files.
-	        "ObjStm",
-	        "XObject",
-	        "XML",
-	        "Xref"
-        };
+const std::vector<std::string> kNonTextDictionary{ // BS-25. Dismiss no text stream objects (/Length1)
+	"/Length1",
+	"/Length2",
+	"/Length3",
+	"/DL",
+	"/EmbeddedFile"
+	};
 
-        class PdfObject {
-	        const std::string kObjBegin			{"obj"};	// Flag to start of 'obj' section
-	        const std::string kObjEnd			{"endobj"}; // Flag of end of 'obj' section
+const std::vector<std::string> kNonTextAttributes{ // BS-25. Dismiss no text stream objects (/Length1)
+	"/ToUnicode",
+	"/FontFile2"
+	};
 
-	        const std::string kFilterTagBegin	{"/Filter"}; // Flag of begin of 'Filter' section
-	        const std::string kFilterTagEnd		{">>"};
-	        const std::string kDictionaryBegin	{"<<"};
-	        const std::string kDictionaryEnd	{">>"};
+const std::vector<std::string> kFileAcceptedKeys{ // BS-26. Detach from PDF attachments specified as files.
+	"/DL",
+	"/EmbeddedFile"
+	};
 
-	        const std::string kStreamBegin		{"stream"}; // Flag of begin of 'stream' section
-	        const std::string kStreamEnd		{"endstream"}; // Flag of end of 'stream' section
+const std::vector<std::string> kNonFileAttributes{ // BS-26. Detach from PDF attachments specified as files.
+	"/Contents",
+	"/ToUnicode",
+	"/FontFile2"
+	};
 
-	        const char* kPdfEol1 = "\n";
-	        const char* kPdfEol2 = "\r\n";
+const std::vector<std::string> kNonFileDictionary{ // BS-26. Detach from PDF attachments specified as files.
+	"/ObjStm",
+	"/XObject",
+	"/XML",
+	"/XRef"
+	};
 
-	        std::string id{};
-	        Dictionary dictionary;
+// These operators inside a BT/ET block shall reset the array and literal buffers
+// i.e., the information in those buffers are related to these operators and have not
+// be considered as text
+const std::vector<std::string> kTextResetingOperators {
+	"Tc", "Tw", "Tz", "TL", "Tf", "Tr", "Ts", 	// Text state operators
+	"Td", "TD", "Tm", "T*"						// Text positioning operators
+	};
 
-	        //TODO Use structs instead of isolated members
-	        const uint8_t*	pdf_object{nullptr};		// Pointer to the start of 'obj' object
-	        size_t			object_size{0};				// The size of 'obj' object
 
-	        const uint8_t* dictionary_start{nullptr};
-	        const uint8_t* dictionary_end{nullptr};
+class PdfObject {
+	const std::string kObjBegin			{"obj"};	// Flag to start of 'obj' section
+	const std::string kObjEnd			{"endobj"}; // Flag of end of 'obj' section
 
-	        const uint8_t*	stream_start{nullptr};			// Pointer to the start of stream part in uint8_t*
-	        const uint8_t*	stream_end{nullptr};			// Pointer to the end of stream part in uint8_t*
-	        size_t			stream_size{0};
+	const std::string kNameTagBegin		{"/"};
 
-	        std::vector<uint8_t> decoded_stream_vector{};
-	        uint8_t*			decoded_stream{nullptr};
-	        size_t				decoded_stream_size{0};
-	        size_t				text_size{0};
-	        std::vector<uint8_t> parsed_text{};
+	const std::string kFilterTagEnd		{">>"};
 
-	        std::vector<uint8_t> file{};				// extracted file
+	const std::string kArrayTagBegin	{"["};
 
-	        std::vector<std::string> filters{};
+	const std::string kStreamBegin		{"stream"}; // Flag of begin of 'stream' section
+	const std::string kStreamEnd		{"endstream"}; // Flag of end of 'stream' section
 
-	        void GetFilters();
-	        void GetStream();
-	        void FlateLZWDecode();
-	        void UnfoldDictionary(Dictionary* dictionary, const uint8_t* begin, const uint8_t* end);
-	        DictionaryBoundaries GetDictionaryBoundaries (const uint8_t* begin, const uint8_t* end);
+	const std::string kFontTagBegin		{"/Font"}; // Indicates the font definition begin
 
-        public:
-	        PdfObject(const uint8_t* buffer, size_t size);
-	        ~PdfObject();
+	const char* kPdfEol1 = "\n";
+	const char* kPdfEol2 = "\r\n";
 
-	        std::string GetId();
-	        Dictionary* GetDictionary();
-	        bool ExtractStream(std::string filter);
-	        std::vector<uint8_t> GetDecodedStream();
-	        void TextParser();
-        	std::vector<uint8_t> GetParsedText();
-	        const uint8_t* GetObjectEnd();
-	        bool HasStream();
-        };
 
-    } // !extern "C"
+	std::string id{};
+	Dictionary dictionary{};
+
+	//TODO Use structs instead of isolated members
+	const uint8_t*	pdf_object{nullptr};		// Pointer to the start of 'obj' object
+	size_t			object_size{0};				// The size of 'obj' object
+
+	const uint8_t* dictionary_start{nullptr};	// Root dictionary
+	const uint8_t* dictionary_end{nullptr};		// Root dictionary
+
+	const uint8_t*	stream_start{nullptr};		// Pointer to the start of stream part in uint8_t*
+	const uint8_t*	stream_end{nullptr};		// Pointer to the end of stream part in uint8_t*
+	size_t			stream_size{0};
+
+	std::vector<uint8_t> decoded_stream_vector{}; // Stream after decode (eg. FlatDecode)
+	uint8_t*			decoded_stream{nullptr};
+	size_t				decoded_stream_size{0};
+	size_t				text_size{0};
+	std::vector<uint8_t> parsed_plain_text{};		// BOM for Little Endian {0xff, 0xfe}. Not needed if endianess is specified en conversion;
+	std::string			parsed_plain_text_utf8{};
+
+	std::vector<uint8_t> file{};				// extracted file
+
+	std::vector<std::string> filters{};
+
+
+	void GetFilters();
+	void GetStream();
+	void ParseTextArray(std::string& array, Font& font);
+	std::string ParseTextLiteral(std::string& text);
+	void FlateLZWDecode();
+	DictionaryBoundaries GetDictionaryBoundaries (const uint8_t* begin, const uint8_t* end);
+
+public:
+	PdfObject(const uint8_t* buffer, size_t size);
+	PdfObject();
+	~PdfObject();
+
+	std::string GetId();
+	Dictionary* GetDictionary();
+	bool ExtractStream(std::string filter);
+
+	/**
+	 * @brief	Examines the dictionary of the object looking for /Font definition and return it if it exist
+	 * @example Returns "65 0" doing reference to 65 0 R where Font is stored or "/F1 5 0 R" in the case font definition embedded
+	 * @param pointer to a dictionary struct
+	 * @return string containing /Font definition reference information. Empty string otherwise
+	 */
+	std::string ExtractFontDefinition(Dictionary* dictionary);
+
+	void UnfoldDictionary(Dictionary* dictionary, const uint8_t* begin, const uint8_t* end);
+
+	std::vector<uint8_t> GetDecodedStream();
+
+	/**
+	 * @brief Once stream is decoded, it parses the contained text inside BT/ET blocks applying fonts
+	 * @param fonts Maps of fonts to translate chars from CID to Unicode when necessary
+	 */
+	void ParseText(std::map<std::string, Font>& fonts);
+
+	std::vector<uint8_t> GetParsedPlainText(TextEncoding encoding);
+	const uint8_t* GetObjectEnd();
+	bool HasStream();
+};
+
+
+} // !extern "C"
 
 } // !namespace pdfparser
 
-#endif /* PDF_OBJECT_H_ */
+
+#endif /* OBJECT_H_ */

--- a/libs/pdf_parser.cpp
+++ b/libs/pdf_parser.cpp
@@ -1,61 +1,75 @@
-/*****************************************************************************
- *
- * YEXTEND: Help for YARA users.
- * This file is part of yextend.
- *
- * Copyright (c) 2014-2018, Bayshore Networks, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- * the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- * following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
+//============================================================================
+// Name        : PDFParser.cpp
+// Author      : Rodrigo de Francisco
+// Version     :
+// Copyright   : Your copyright notice
+// Description : Hello World in C++, Ansi-style
+//============================================================================
 
-#include "pdf_parser_helper.h"
-#include "pdf.h"
+/* Include order
+Own .h.
+C.
+C++.
+Other libraries' .h files.
+Your project's .h files.
+*/
+
+#include "pdf_parser.h"
+
+//#include "pdf.h"
+
 
 extern "C" {
 
-    namespace pdfparser {
+namespace pdfparser {
 
-        /**
-         *
-         * @param pdf_pointer pointer where the pdf is loaded
-         * @param pdf_size size of pdf
-         * @return vector with decoded text. Text blocks are separated by \n. User should copy the decoded text.
-         */
-        std::vector<uint8_t> PdfToText (const uint8_t* pdf_pointer, size_t pdf_size) {
-	        Pdf pdf{pdf_pointer, pdf_size};
 
-	        std::vector<uint8_t> text_buffer = pdf.ExtractText();
+/**
+ *
+ * @param pdf_pointer pointer where the pdf is loaded
+ * @param pdf_size size of pdf
+ * @return vector with decoded text. Text blocks are separated by \n. User should copy the decoded text.
+ */
+std::vector<uint8_t> PdfToText (const uint8_t* pdf_pointer, size_t pdf_size, pdfparser::TextEncoding encoding) {
 
-	        return text_buffer;
-        }
+	Pdf pdf{pdf_pointer, pdf_size};
+	auto text_buffer = pdf.ExtractText(encoding); // TODO BS-54
+	return text_buffer;
+}
 
-        std::vector<std::vector<uint8_t>> PdfDetach (const uint8_t* pdf_pointer, size_t pdf_size) {
-	        Pdf pdf{pdf_pointer, pdf_size};
 
-	        std::vector<std::vector<uint8_t>> file_buffer = pdf.ExtractFile();
+PDF_DETACH PdfDetach (const uint8_t* pdf_pointer, size_t pdf_size) {
 
-	        return file_buffer;
-        }
+	Pdf pdf{pdf_pointer, pdf_size};
+	std::vector<std::vector<uint8_t>> file_buffer = pdf.ExtractFile(); // TODO BS-54
+	return file_buffer;
+}
 
-    } // !namespace pdfparser
+
+
+	// TODO BS-55
+	/*
+	std::vector<std::vector<uint8_t>> files_buffer{}; // To store files
+	auto current_pdf_pointer = pdf_pointer;
+	auto current_pdf_size = pdf_size;
+	std::vector<std::string> file_obj_pointers{};	// Pointers to objects containing '/Type Filespec'
+
+	//Pdf pdf{current_pdf_pointer, current_pdf_size};
+
+	while (current_pdf_size > 0 && current_pdf_size != std::string::npos){
+		PdfObject pdf_object{current_pdf_pointer, current_pdf_size};
+
+		//pdf_object.ExtractFileObjects();
+		//current_text = pdf_object.DecodeText(); // Get the actual text
+
+
+
+		current_pdf_size = current_pdf_size - (pdf_object.GetObjectEnd() - current_pdf_pointer);
+		current_pdf_pointer = pdf_object.GetObjectEnd();
+	}
+	return std::vector<std::vector<uint8_t>>{};
+*/
+
+} // !namespace pdfparser
 
 } // !extern "C"

--- a/libs/pdf_parser.h
+++ b/libs/pdf_parser.h
@@ -24,7 +24,7 @@ extern "C" {
 using PDF_DETACH = std::vector<std::vector<uint8_t>>;
 
 
-std::vector<uint8_t> PdfToText (const uint8_t* pdf_start, size_t pdf_size, TextEncoding encoding);
+std::vector<uint8_t> PdfToText (const uint8_t* pdf_start, size_t pdf_size, pdfparser::TextEncoding encoding = TextEncoding::raw);
 
 PDF_DETACH PdfDetach (const uint8_t* pdf_start, size_t pdf_size);
 

--- a/libs/pdf_parser.h
+++ b/libs/pdf_parser.h
@@ -1,49 +1,34 @@
-/*****************************************************************************
+/*
+ * pdfparser.h
  *
- * YEXTEND: Help for YARA users.
- * This file is part of yextend.
- *
- * Copyright (c) 2014-2018, Bayshore Networks, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- * the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- * following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
+ *  Created on: Nov 29, 2017
+ *      Author: rodrigo
+ */
 
 #ifndef PDF_PARSER_H_
 #define PDF_PARSER_H_
 
-#include <cstddef>
 #include <stdint.h>
+
+#include <cstddef>
 #include <vector>
 
 #include "pdf.h"
+#include "pdf_text_encoding.h"
 
 namespace pdfparser {
 
-    extern "C" {
+extern "C" {
 
-        std::vector<uint8_t> PdfToText (const uint8_t* pdf_start, size_t pdf_size);
-        std::vector<std::vector<uint8_t>> PdfDetach (uint8_t* pdf_start, size_t pdf_size);
 
-    } // !extern "C"
+using PDF_DETACH = std::vector<std::vector<uint8_t>>;
+
+
+std::vector<uint8_t> PdfToText (const uint8_t* pdf_start, size_t pdf_size, TextEncoding encoding);
+
+PDF_DETACH PdfDetach (const uint8_t* pdf_start, size_t pdf_size);
+
+} // !extern "C"
 
 } // !namespace pdfparser
 

--- a/libs/pdf_parser_helper.cpp
+++ b/libs/pdf_parser_helper.cpp
@@ -1,31 +1,16 @@
-/*****************************************************************************
+/*
  *
- * YEXTEND: Help for YARA users.
- * This file is part of yextend.
- *
- * Copyright (c) 2014-2018, Bayshore Networks, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- * the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- * following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
+ *  Created on: Nov 29, 2017
+ *      Author: rodrigo
+ */
+
+/* Include order
+Own .h.
+C.
+C++.
+Other libraries' .h files.
+Your project's .h files.
+*/
 
 #include <cstring>
 
@@ -40,123 +25,123 @@
 #include <sstream>
 #include <vector>
 
+
 namespace pdfparser {
 
-    extern "C" {
+extern "C" {
 
-        /**
-         * @brief Returns the position of the first needle in the haystack
-         * @param haystack
-         * @param needle
-         * @param haystack_size
-         * @return size_t position in haystack where needle is located
-         */
-        size_t FindStringInBuffer (const uint8_t* haystack, const char* needle, const size_t haystack_size) {
-	        auto haystack_index = haystack;
 
-	        size_t needle_length = std::char_traits<char>::length(needle);
+/**
+ * @brief Returns the position of the first needle in the haystack
+ * @param haystack
+ * @param needle
+ * @param haystack_size
+ * @return size_t position in haystack where needle is located
+ */
+size_t FindStringInBuffer (const uint8_t* haystack, const char* needle, const size_t haystack_size) {
+	auto haystack_index = haystack;
 
-	        bool found = false;
-	        while (!found) {
-		        found = true;
-		        for (size_t i=0; i<needle_length; ++i) {
-			        if (haystack_index[i]!=needle[i]) {
-				        found = false;
-				        break;
-			        }
-		        }
+	size_t needle_length = std::char_traits<char>::length(needle);
 
-		        if (found)
-                    return haystack_index - haystack;
+	bool found = false;
+	while (!found) {
+		found = true;
+		for (size_t i=0; i<needle_length; ++i) {
+			if (haystack_index[i]!=needle[i]) {
+				found = false;
+				break;
+			}
+		}
+		if (found) return haystack_index - haystack;
+		haystack_index++;
+		if (haystack_index - haystack + needle_length >= haystack_size){
+			return std::string::npos;
+		}
+	}
+	return std::string::npos;
+}
 
-		        haystack_index++;
 
-		        if (haystack_index - haystack + needle_length >= haystack_size)
-			        return std::string::npos;
-	        }
+size_t FindStringInBufferReverse (const uint8_t* haystack, const char* needle, const size_t haystack_size) {
+	auto haystack_index = haystack+haystack_size;
 
-	        return std::string::npos;
-        }
+	size_t needle_length = std::char_traits<char>::length(needle);
 
-        size_t FindStringInBufferReverse (const uint8_t* haystack, const char* needle, const size_t haystack_size) {
-	        auto haystack_index = haystack+haystack_size;
+	bool found = false;
+	while (!found) {
+		found = true;
+		for (size_t i=1; i<needle_length; ++i) { //Starts in 1 to avoid '/0' at the end of needle. Length is 1 based and needle is 0 based
+			if (haystack_index[-i]!=needle[needle_length-i]) { // reversed direction
+				found = false;
+				break;
+			}
+		}
+		if (found) return haystack_index - haystack;
+		--haystack_index;
+		if (haystack_index - haystack - needle_length == 0){ // Begin of haystack reached
+			return std::string::npos;
+		}
+	}
+	return std::string::npos;
+}
 
-	        size_t needle_length = std::char_traits<char>::length(needle);
 
-	        bool found = false;
-	        while (!found) {
-		        found = true;
-		        for (size_t i=1; i<needle_length; ++i) { //Starts in 1 to avoid '/0' at the end of needle. Length is 1 based and needle is 0 based
-			        if (haystack_index[-i]!=needle[needle_length-i]) { // reversed direction
-				        found = false;
-				        break;
-			        }
-		        }
-		        if (found)
-                    return haystack_index - haystack;
+/**
+ * @brief Splits the string in 'quantity' pieces using delim as delimiter
+ * @param string	is the string to be splitted
+ * @param delim		string is splitted using this char as delimiter
+ * @param quantity	is the quantity of splits. 1 return de first split and the rest. If std::string::npos it splits the whole string
+ * @return
+ */
+std::vector<std::string> SplitString(std::string const & string, char delim, size_t quantity=std::string::npos)
+{
+    std::vector<std::string> result;
+    std::istringstream iss(string);
 
-		        --haystack_index;
+    std::string token;
+    while (std::getline(iss, token, delim) && quantity > 0)
+    //for (std::string token; std::getline(iss, token, delim); )
+    {
+    	result.push_back(std::move(token));
+    	quantity--;
+    }
+    if (quantity == 0){
+    	result.push_back(std::move(token));
+    }
+    return result;
+}
 
-		        if (haystack_index - haystack - needle_length == 0) { // Begin of haystack reached
-			        return std::string::npos;
-		        }
-	        }
-	        return std::string::npos;
-        }
+/**
+ * @brief	Splits the string by any of the characters included in delim
+ * @param string
+ * @param delim
+ * @return
+ */
+std::vector<std::string> SplitStringAnyChar(std::string const & string, std::string const & delim, size_t quantity) {
+	std::vector<std::string> word_vector{};
+	std::stringstream stringStream(string);
+	std::string line;
 
-        /**
-         * @brief Splits the string in 'quantity' pieces using delim as delimiter
-         * @param string	is the string to be splitted
-         * @param delim		string is splitted using this char as delimiter
-         * @param quantity	is de quantity of splits. 1 return de first split and the rest. If std::string::npos it splits the whole string
-         * @return
-         */
-        std::vector<std::string> SplitString(std::string const & string, char delim, size_t quantity) {
-            std::vector<std::string> result;
-            std::istringstream iss(string);
+	while(std::getline(stringStream, line)) {
+		std::size_t prev = 0, pos;
 
-            std::string token;
-            while (std::getline(iss, token, delim) && quantity > 0) {
-            	result.push_back(std::move(token));
-            	quantity--;
-            }
+		while (((pos = line.find_first_of(delim, prev)) != std::string::npos) && (quantity >0))
+		{
+			if (pos > prev) {
+				word_vector.push_back(line.substr(prev, pos-prev));
+				--quantity;
+			}
+			prev = pos+1;
+		}
+		if ((prev < line.length()) || (quantity == 0))
+			word_vector.push_back(line.substr(prev, std::string::npos));
+	}
 
-            if (quantity == 0)
-            	result.push_back(std::move(token));
+	return word_vector;
+}
 
-            return result;
-        }
 
-        /**
-         * @brief	Splits the string by any of the characters included in delim
-         * @param string
-         * @param delim
-         * @return
-         */
-        std::vector<std::string> SplitStringAnyChar(std::string const & string, std::string const & delim, size_t quantity) {
-	        std::vector<std::string> word_vector{};
-	        std::stringstream stringStream(string);
-	        std::string line;
-
-	        while(std::getline(stringStream, line)) {
-		        std::size_t prev = 0, pos;
-
-		        while (((pos = line.find_first_of(delim, prev)) != std::string::npos) && (quantity >0)) {
-			        if (pos > prev) {
-				        word_vector.push_back(line.substr(prev, pos-prev));
-				        --quantity;
-			        }
-
-			        prev = pos+1;
-		        }
-
-		        if ((prev < line.length()) || (quantity == 0))
-			        word_vector.push_back(line.substr(prev, std::string::npos));
-	        }
-
-	        return word_vector;
-        }
-
-    } // !extern "C"
+} // !extern "C"
 
 } // !namespace pdfparser
+

--- a/libs/pdf_parser_helper.h
+++ b/libs/pdf_parser_helper.h
@@ -1,34 +1,12 @@
-/*****************************************************************************
+/*
+ * parser.h
  *
- * YEXTEND: Help for YARA users.
- * This file is part of yextend.
- *
- * Copyright (c) 2014-2018, Bayshore Networks, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- * the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- * following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
+ *  Created on: Nov 29, 2017
+ *      Author: rodrigo
+ */
 
-#ifndef PDF_PARSER_HELPER_H_
-#define PDF_PARSER_HELPER_H_
+#ifndef PARSER_HELPER_H_
+#define PARSER_HELPER_H_
 
 #include <stdint.h>
 
@@ -37,16 +15,19 @@
 #include <unordered_map>
 #include <vector>
 
+
+
 namespace pdfparser {
 
-    extern "C" {
+extern "C" {
 
-        size_t FindStringInBuffer (const uint8_t* haystack, const char* needle, const size_t haystack_size);
-        size_t FindStringInBufferReverse (const uint8_t* haystack, const char* needle, const size_t haystack_size);
-        std::vector<std::string> SplitString(std::string const & string, char delim, size_t quantity = std::string::npos);
+size_t FindStringInBuffer (const uint8_t* haystack, const char* needle, const size_t haystack_size);
+size_t FindStringInBufferReverse (const uint8_t* haystack, const char* needle, const size_t haystack_size);
+std::vector<std::string> SplitString(std::string const & string, char delim, size_t quantity = std::string::npos);
 
-    } // !extern "C"
+} // !extern "C"
 
 } // !namespace pdfparser
 
-#endif /* PDF_PARSER_HELPER_H_ */
+
+#endif /* PARSER_HELPER_H_ */

--- a/libs/pdf_text_encoding.h
+++ b/libs/pdf_text_encoding.h
@@ -1,0 +1,21 @@
+#ifndef TEXT_ENCODING_H_
+#define TEXT_ENCODING_H_
+
+namespace pdfparser {
+
+
+extern "C" {
+
+
+enum class TextEncoding {
+	raw,
+	utf8
+};
+
+
+} // !extern C
+
+
+} // !namespace
+
+#endif // TEXT_ENCODING_H_


### PR DESCRIPTION
Fix from @defrancr in the PDF Parser libs in order to be able to parse PDFs with non-standard fonts