### PR TITLE
Putty pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ yextend
 Makefile_*
 cov-int/*
 run_coverity_scan
+.bash_history

--- a/Makefile.am
+++ b/Makefile.am
@@ -38,12 +38,20 @@ include_HEADERS = libs/json.hpp \
 				libs/zl.h \
 				libs/pdf_parser.h \
 				libs/bzl.h
-				
-				
+
+
 lib_YARA = /usr/local/lib
 
 bin_PROGRAMS = yextend
-yextend_SOURCES = libs/json.hpp wrapper.cpp bayshore_content_scan.cpp libs/bayshore_file_type_detect.cpp main.cpp libs/zl.cpp libs/bayshore_yara_wrapper.c libs/pdf_parser.cpp libs/bzl.cpp
+yextend_SOURCES = libs/json.hpp \
+				wrapper.cpp \
+				bayshore_content_scan.cpp \
+				libs/bayshore_file_type_detect.cpp \
+				main.cpp \
+				libs/zl.cpp \
+				libs/bayshore_yara_wrapper.c \
+				libs/pdf_parser.cpp \
+				libs/bzl.cpp
 
 unittests:
 	cd test; nosetests -s; cd ..

--- a/Makefile.am
+++ b/Makefile.am
@@ -40,7 +40,8 @@ include_HEADERS = libs/json.hpp \
 				libs/pdf_parser.h \
 				libs/pdf_parser_helper.h \
 				libs/pdf.h \
-				libs/pdf_object.h
+				libs/pdf_object.h \
+				libs/pdf_font.h
 
 
 lib_YARA = /usr/local/lib
@@ -57,7 +58,8 @@ yextend_SOURCES = libs/json.hpp \
 				libs/pdf_parser.cpp \
 				libs/pdf_parser_helper.cpp \
 				libs/pdf.cpp \
-				libs/pdf_object.cpp
+				libs/pdf_object.cpp \
+				libs/pdf_font.cpp
 
 
 unittests:

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@
 # YEXTEND: Help for YARA users.
 # This file is part of yextend.
 #
-# Copyright (c) 2014-2017, Bayshore Networks, Inc.
+# Copyright (c) 2014-2018, Bayshore Networks, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted provided that
@@ -36,8 +36,11 @@ include_HEADERS = libs/json.hpp \
 				bayshore_content_scan.h \
 				libs/bayshore_file_type_detect.h \
 				libs/zl.h \
+				libs/bzl.h \
 				libs/pdf_parser.h \
-				libs/bzl.h
+				libs/pdf_parser_helper.h \
+				libs/pdf.h \
+				libs/pdf_object.h
 
 
 lib_YARA = /usr/local/lib
@@ -50,8 +53,12 @@ yextend_SOURCES = libs/json.hpp \
 				main.cpp \
 				libs/zl.cpp \
 				libs/bayshore_yara_wrapper.c \
+				libs/bzl.cpp \
 				libs/pdf_parser.cpp \
-				libs/bzl.cpp
+				libs/pdf_parser_helper.cpp \
+				libs/pdf.cpp \
+				libs/pdf_object.cpp
+
 
 unittests:
 	cd test; nosetests -s; cd ..

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ yextend was written for the sake of augmenting yara. yara by itself is great but
 
 
 Software Credits
-	
+
 	- Yara is originally authored by Victor M. Alvarez (https://github.com/VirusTotal/yara) - License: https://raw.githubusercontent.com/VirusTotal/yara/master/COPYING
 	- json.hpp is authored by Niels Lohmann (https://github.com/nlohmann/json) - License: https://raw.githubusercontent.com/nlohmann/json/develop/LICENSE.MIT  *** Note that for Yextend to compile I had to make a change to the original json.hpp - function "get_string" was causing name conflicts with function "get_string" from Yara. So I renamed json.hpp's function to "j_get_string"
 
@@ -45,7 +45,7 @@ Notes:
 
 	- output now includes the offset and string definition identifier for every hit reported by Yara
 	- output now includes the name of the Yara ruleset file at hand
-	- initial release of run_yextend prog 
+	- initial release of run_yextend prog
 
 - (10/24/2015) yextend version 1.3 will only work with yara 3.4.
 
@@ -69,7 +69,6 @@ Requirements to build and run:
 - libarchive (v4) be installed (sudo dnf install libarchive-devel or sudo apt-get install libarchive-dev)
 - pcrecpp (sudo dnf install pcre-devel or sudo apt-get install libpcre3-dev)
 - uuid (sudo dnf install uuid-devel / libuuid-devel or sudo apt-get install uuid-dev)
-- pdf2text (sudo dnf install poppler-utils or sudo apt-get install poppler-utils)
 - nose (sudo dnf install python2-nose or sudo apt-get install python-nose)
 - yara v3.X be fully installed
 - if you are running yara pre-version 3.1.X then yara v3 lib header files to be moved to a specific location after a typical yara install, steps:
@@ -98,10 +97,10 @@ Instructions:
 5 - Run:
 
 	- Note on run modes:
-	
+
 		- No arguments/switches passed in means the output is intended for human eyes
 		- The -j switch means the output is for machine to consume [JSON]
-		- The -a switch, used in conjunction -j, means that file structure/hierarchy will be added to the machine consumable JSON output 
+		- The -a switch, used in conjunction -j, means that file structure/hierarchy will be added to the machine consumable JSON output
 
 	- 2 options to run:
 
@@ -122,7 +121,7 @@ Instructions:
 		 ./run_yextend -r rule_entity -t target_file_entity
         ./run_yextend --ruleset rule_entity -t target_file_entity
         ./run_yextend -r rule_entity -t target_file_entity -j
-        
+
 		***** make sure the executable bit is set on the file system for run_yextend *****
 
 	B. run yextend executable - prefix the run statement by telling LD_LIBRARY_PATH where the yara shared object lib (or its symlink) is. If you changed nothing during the yara install then that value is '/usr/local/lib'
@@ -132,31 +131,31 @@ Instructions:
 		1. A yara ruleset file
 		2. A file name or a directory name where the target files exist
 		3. '-j' for json output [optional]
-		
+
 	usage:
         -r rule_entity
         -t target_file_entity
         -j
-	
+
 	example:
-	
+
 		- LD_LIBRARY_PATH=/usr/local/lib ./yextend -r ~/Desktop/bayshore.yara.rules -t /tmp/targetfiles/filex
 		- LD_LIBRARY_PATH=/usr/local/lib ./yextend -r ~/Desktop/bayshore.yara.rules -t /tmp/targetfiles/
 		- LD_LIBRARY_PATH=/usr/local/lib ./yextend -r ~/Desktop/bayshore.yara.rules -t /tmp/targetfiles/filex -j
-		
-		***** 
+
+		*****
 			if you don't want to set LD_LIBRARY_PATH on each prog run then you can set it in your .bashrc (or equivalent on your system) as such:
-		
+
 			export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-			
+
 			then the program runs would be as such:
-	
+
 				- ./yextend -r ~/Desktop/bayshore.yara.rules -t /tmp/targetfiles/filex
 				- ./yextend -r ~/Desktop/bayshore.yara.rules -t /tmp/targetfiles/			
 		*****
 
 6 - Analyze output. The output will be structured as such (number of result stanzas will obviously vary based on the content at hand):
-	
+
 	===============================ALPHA===================================
 	Ruleset File Name: w
 	File Name: x
@@ -170,8 +169,8 @@ Instructions:
 	Parent File Name: b
 	Child File Name: c
 	File Signature (MD5): d
-	
-	
+
+
 	Yara Result(s): RULE2, RULEWITHMETA:[type=Simple string search,signature=Looking for 95,author=Dre,testint=9,d=false,detected offsets=0x0:$a-0x1:$a-0x2:$a-0x3:$a,hit_count=4], RULE3
 	Scan Type: v
 	Parent File Name: x
@@ -186,7 +185,7 @@ Instructions:
 		RULE_ID:[META_DATA,OFFSETS,HIT_COUNT], RULE_ID[OFFSETS,HIT_COUNT], ... RULE_ID[OFFSETS,HIT_COUNT]
 
 		Inside the square brackets:
-		
+
 			The "META_DATA" are comma-separated and represent the data from your rules "meta" section. As this is optional you may see no meta-data output from yextend.
 			The OFFSETS are comma-separated. Each offset listing is delimited by a dash and represent the offset in the content where the rule hit took place and the respective string definition identifier from your Yara rule.
 			The HIT_COUNT is simply a listing of the number of rule hits.
@@ -209,37 +208,37 @@ Instructions:
 			OFFSETS: detected offsets=0xd94e:$a-0x2c5b5:$b ("0xd94e" is one offset in the content that hit on string definition "$a". "0x2c5b5" is another offset in the content that hit on string definition "$b")
 			HIT_COUNT: hit_count=2
 
-		
-		
+
+
 	A. example output from one of the test files:
-	
+
 		===============================ALPHA===================================
 		Ruleset File Name: test_rules/ruleset_blah
 		File Name: test_files/rands_tarball.tar.gz
 		File Size: 271386
 		File Signature (MD5): 74edc10648f6d65e90cd859120eaa31b
-		
+
 		=======================================================================
-		
+
 		Yara Result(s): JUDO:[detected offsets=0x48:$a,hit_count=1]
 		Scan Type: Yara Scan (ASCII Text File) inside GZIP Archive file
 		Parent File Name: AAA.gz
 		Child File Name: AAA
 		File Signature (MD5): bf6aadaf4b6fb726040c1131d809bfc2
-		
-		
+
+
 		Yara Result(s): EXE_DROP:[detected offsets=0x4e:$a,hit_count=1], MZ_PORTABLE_EXE, S95:[detected offsets=0xd94e:$a-0x2c5b5:$a,hit_count=2]
 		Scan Type: Yara Scan (Windows - Portable Executable) inside ZIP 2.0 (deflation) file
 		Parent File Name: rand987.zip
 		Child File Name: spoolsy.exe
 		File Signature (MD5): 25ca7beed707e94ce70137f7d0c7b14e
-		
-		
+
+
 		===============================OMEGA===================================
-		
-		
+
+
 		This is based on file "test_files/rands_tarball.tar.gz" that has the following structure:
-		
+
 		rands_tarball.tar.gz
 		|_ rands.tar
 		   |_ rand123.zip
@@ -328,7 +327,7 @@ Instructions:
 
 
 		This last example is based on file "test_files/step1-zips.tar.gz" that has the following structure:
-		
+
 		step1-zips.tar.gz
 		|_ docx-embedded-step3.xlsx.zip
 		   |_ docx-embedded-step3.xlsx
@@ -392,74 +391,72 @@ Instructions:
         		"yara_ruleset_file_name": "test_rulesets/BAYSHORE_Officex1.yar"
     		}
 		]
-		
-		
+
+
 	D. An example of advanced JSON output:
-		
+
              ./run_yextend -r test_rulesets/BAYSHORE_Officex1.yar -t test_files/Lorem-winlogon.docx.bz2 -j -a
              [
                  {
-                     "yara_matches_found": true, 
+                     "yara_matches_found": true,
                      "scan_results": [
                          {
-                             "yara_matches_found": false, 
-                             "file_name": "test_files/Lorem-winlogon.docx", 
-                             "file_size": 210193, 
+                             "yara_matches_found": false,
+                             "file_name": "test_files/Lorem-winlogon.docx",
+                             "file_size": 210193,
                              "children": [
                                  {
-                                     "yara_matches_found": false, 
-                                     "file_size": 29639, 
-                                     "file_name": "word/document.xml", 
-                                     "file_signature_MD5": "9d58972d9a528da89c971597e4aa1844", 
+                                     "yara_matches_found": false,
+                                     "file_size": 29639,
+                                     "file_name": "word/document.xml",
+                                     "file_signature_MD5": "9d58972d9a528da89c971597e4aa1844",
                                      "scan_type": "Yara Scan (Office Open XML)  inside BZIP2 Archive file"
-                                 }, 
+                                 },
                                  {
-                        	     "yara_matches_found": true, 
-                                     "file_name": "word/embeddings/oleObject1.bin", 
-                        	     "scan_type": "Yara Scan (Microsoft Office document (DOC PPT XLS)) embedded in an Office Open XML file", 
+                        	     "yara_matches_found": true,
+                                     "file_name": "word/embeddings/oleObject1.bin",
+                        	     "scan_type": "Yara Scan (Microsoft Office document (DOC PPT XLS)) embedded in an Office Open XML file",
                                      "yara_results": {
                                          "maldoc_suspicious_strings": {
-                                             "description": "suspicious marco action", 
-                                             "hit_count": "8", 
+                                             "description": "suspicious marco action",
+                                             "hit_count": "8",
                                              "offsets": [
-                                                "0x12231:$a02", 
-                                                "0x135c5:$a03", 
-                                                "0x55dc7:$a03", 
-                                                "0x5f1e2:$a03", 
-                                                "0x55db9:$a09", 
-                                                "0x5f1d5:$a09", 
-                                                "0x55e31:$a12", 
+                                                "0x12231:$a02",
+                                                "0x135c5:$a03",
+                                                "0x55dc7:$a03",
+                                                "0x5f1e2:$a03",
+                                                "0x55db9:$a09",
+                                                "0x5f1d5:$a09",
+                                                "0x55e31:$a12",
                                                 "0x1037d:$a15"
                                              ]
                                          }
-                                     }, 
-                                     "file_size": 392192, 
+                                     },
+                                     "file_size": 392192,
                                      "file_signature_MD5": "27250593fccbfb679320a74be9459d17"
-                                 }, 
+                                 },
                                  {
-                                     "yara_matches_found": false, 
-                                     "file_size": 8, 
-                                     "file_name": "word/embeddings/oleObject1.bin", 
-                                     "file_signature_MD5": "6674f1535a94304e58f26d06f348190d", 
+                                     "yara_matches_found": false,
+                                     "file_size": 8,
+                                     "file_name": "word/embeddings/oleObject1.bin",
+                                     "file_signature_MD5": "6674f1535a94304e58f26d06f348190d",
                                      "scan_type": "Yara Scan (Office Open XML)  inside BZIP2 Archive file"
                                  }
-                             ], 
+                             ],
                              "file_signature_MD5": "d8f0fab30eae91687c0d80f8dd08218f"
                          }
-                     ], 
-       	             "file_name": "test_files/Lorem-winlogon.docx.bz2", 
-       	             "yara_ruleset_file_name": "test_rulesets/BAYSHORE_Officex1.yar", 
-       	             "file_size": 208940, 
+                     ],
+       	             "file_name": "test_files/Lorem-winlogon.docx.bz2",
+       	             "yara_ruleset_file_name": "test_rulesets/BAYSHORE_Officex1.yar",
+       	             "file_size": 208940,
        	             "children": [
                         {
-               	            "yara_matches_found": false, 
-               	            "file_size": 210193, 
-                            "file_name": "test_files/Lorem-winlogon.docx", 
+               	            "yara_matches_found": false,
+               	            "file_size": 210193,
+                            "file_name": "test_files/Lorem-winlogon.docx",
                             "file_signature_MD5": "d8f0fab30eae91687c0d80f8dd08218f"
                         }
-                    ], 
+                    ],
                     "file_signature_MD5": "26b485701d6a47618a7f915aa7a38045"
                 }
             ]
-		
-		

--- a/bayshore_content_scan.cpp
+++ b/bayshore_content_scan.cpp
@@ -276,7 +276,8 @@ void scan_pdf_api(void *cookie,
 	 * completes
 	 */
 	std::string str_buf;
-	PDFParser pdf(ssp_local->buffer, ssp_local->buffer_length);
+	auto pdf_temp = pdfparser::PdfToText((uint8_t *)ssp_local->buffer, ssp_local->buffer_length);
+	str_buf = std::string (pdf_temp.begin(), pdf_temp.end());
 
 	/*
 	 * 2.
@@ -285,10 +286,10 @@ void scan_pdf_api(void *cookie,
 	 */
 	if (in_type_of_scan == 1) {
 
-		str_buf = pdf.extract_text_buffer();
-
+		//str_buf = pdf.extract_text_buffer();
 		ssp_local->buffer = (const uint8_t*)str_buf.c_str();
 		ssp_local->buffer_length = str_buf.length();
+
 	}
 
 	//std::cout << "EMBED: " << pdf.has_embedded_files() << std::endl;
@@ -308,6 +309,7 @@ void scan_pdf_api(void *cookie,
 	// These can no longer be used.
 	ssp_local->buffer = NULL;
 	ssp_local->buffer_length = 0;
+	
 }
 
 

--- a/bayshore_content_scan.cpp
+++ b/bayshore_content_scan.cpp
@@ -5,19 +5,19 @@
  *
  * Copyright (c) 2014-2017, Bayshore Networks, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
  * following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
  * following disclaimer in the documentation and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
  * products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
@@ -51,12 +51,7 @@ extern "C" {
 #include <openssl/md5.h>
 #include <algorithm>
 
-///////////////////////////////////////////////////////
-#define DEBUG_PREFIX "[DEBUG]"
-#define IN_FUNC " in function "
 
-bool DEBUG = false;
-//bool DEBUG = true;
 ///////////////////////////////////////////////////////
 
 struct security_scan_parameters_t {
@@ -68,7 +63,7 @@ struct security_scan_parameters_t {
 	char scan_type [300];
 	int file_type;
 	YR_RULES *rules;
-	
+
 	security_scan_parameters_t() {
 		buffer = 0;
 		buffer_length = 0;
@@ -87,10 +82,10 @@ int archive_failure_counter = 0;
 
 /*
  * type of scan - const data
- * 
+ *
  * order matters - DO NOT CHANGE,
  * add at the bottom of array
- */ 
+ */
 static const char *type_of_scan[] = {
 		"Generic", // internal use only
 		"Yara Scan"
@@ -112,7 +107,7 @@ static void scan_content2 (
 //////////////////////////////////////////////////////////////
 // helper functions
 
-char *str2md5(const char *str, int length) 
+char *str2md5(const char *str, int length)
 {
     int n;
     MD5_CTX c;
@@ -165,15 +160,15 @@ void increment_archive_failure_counter() {
 }
 
 double get_failure_percentage() {
-	
+
 	double total = iteration_counter - 1;
-	
+
 	if (archive_failure_counter > 1 && total > 1)
 		return ((double)total/(double)archive_failure_counter) * 100;
 	return 0.0;
 }
 
-std::string strip_office_open_xml(std::string content, std::string file_type) 
+std::string strip_office_open_xml(std::string content, std::string file_type)
 {
 
 	std::string regex = "";
@@ -250,15 +245,13 @@ void scan_pdf_api(void *cookie,
 		int in_type_of_scan
 		)
 {
-	if (DEBUG)
-		std::cout << DEBUG_PREFIX << IN_FUNC << __FUNCTION__ << std::endl;
-	
+
 	security_scan_parameters_t *ssp_local = (security_scan_parameters_t *)cookie;
 	assert(ssp_local);
-	
+
 	size_t src_len = 0;
 	if (src) src_len = strlen(src);
-	
+
 	/////////////////////////////////////////////////////////
 	/*
 	 * 1.
@@ -270,13 +263,13 @@ void scan_pdf_api(void *cookie,
 	} else {
 		snprintf (ssp_local->scan_type, sizeof(ssp_local->scan_type), "%s %s%s", type_of_scan[in_type_of_scan], "(PDF - Raw data)", src);
 	}
-	
+
 	if (child_file_name)
 		cb((void *)ssp_local, ssr_list, child_file_name);
 	else
-		cb((void *)ssp_local, ssr_list, "");	
+		cb((void *)ssp_local, ssr_list, "");
 	/////////////////////////////////////////////////////////
-	
+
 	/*
 	 * declare str_buf here so that it doesnt go
 	 * out of scope when "if (in_type_of_scan == 1)"
@@ -284,7 +277,7 @@ void scan_pdf_api(void *cookie,
 	 */
 	std::string str_buf;
 	PDFParser pdf(ssp_local->buffer, ssp_local->buffer_length);
-	
+
 	/*
 	 * 2.
 	 * scan the extracted text from the PDF so that we
@@ -297,15 +290,15 @@ void scan_pdf_api(void *cookie,
 		ssp_local->buffer = (const uint8_t*)str_buf.c_str();
 		ssp_local->buffer_length = str_buf.length();
 	}
-	
+
 	//std::cout << "EMBED: " << pdf.has_embedded_files() << std::endl;
-	
+
 	if (src_len == 0) {
 		snprintf (ssp_local->scan_type, sizeof(ssp_local->scan_type), "%s %s", type_of_scan[in_type_of_scan], "(PDF - Extracted text)");
 	} else {
 		snprintf (ssp_local->scan_type, sizeof(ssp_local->scan_type), "%s %s%s", type_of_scan[in_type_of_scan], "(PDF - Extracted text)", src);
 	}
-	
+
 	if (child_file_name)
 		cb((void *)ssp_local, ssr_list, child_file_name);
 	else
@@ -334,8 +327,6 @@ void scan_office_open_xml_api(
 		int in_type_of_scan
 		)
 {
-	if (DEBUG)
-		std::cout << DEBUG_PREFIX << IN_FUNC << __FUNCTION__ << std::endl;
 
 	cb(cookie, oxml_ssr_list, parent_file_name ? parent_file_name : "");
 
@@ -345,7 +336,7 @@ void scan_office_open_xml_api(
 
 	size_t src_len = 0;
 	if (NULL!=src) src_len = strlen(src);
-	
+
 	struct archive *a = archive_read_new();
 	assert(a);
 	struct archive_entry *entry;
@@ -366,7 +357,7 @@ void scan_office_open_xml_api(
 	r = archive_read_open_memory(a, (uint8_t *)ssp_local->buffer, ssp_local->buffer_length);
 
 	if (r >= 0) {
-		
+
 		// final sets of data
 		uint8_t *final_buff = (uint8_t*) malloc (2048);
 		final_buff[0] = 0;
@@ -374,9 +365,9 @@ void scan_office_open_xml_api(
 		bool embedded_doc;
 		bool macro_file;
 		std::string file_type = "";
-		
+
 		for (;;) {
-			
+
 			embedded_doc = false;
 			macro_file = false;
 
@@ -390,29 +381,29 @@ void scan_office_open_xml_api(
 
 			if (r < ARCHIVE_WARN)
 				break;
-			
+
 			if (archive_entry_size(entry) > 0) {
-				
+
 				char *fname = strdup(archive_entry_pathname(entry));
 				//std::cout << fname << std::endl;
 
 				if (fname) {
-					
+
 					std::string oox_type = "";
-					
+
 					if ((strncmp (fname, "word/document.xml", 17) == 0) ||
 							(strncmp (fname, "word/header", 11) == 0) ||
 							(strncmp (fname, "word/footer", 11) == 0)
 						) {
 						oox_type = "docx";
 					}
-					
-					if ((strncmp (fname, "ppt/notesSlides/", 16) == 0) || 
+
+					if ((strncmp (fname, "ppt/notesSlides/", 16) == 0) ||
 							(strncmp (fname, "ppt/slides/", 11) == 0)
 						) {
 						oox_type = "pptx";
 					}
-					
+
 					if ((strncmp (fname, "xl/worksheets/", 14) == 0) ||
 							(strncmp (fname, "xl/sharedStrings", 16) == 0)
 							){
@@ -432,7 +423,7 @@ void scan_office_open_xml_api(
 						// The document's content
 						oox_type = "odt";
 					}
-					
+
 					// macro file present
 					if (strncmp(fname, "word/vbaProject.bin", 19) == 0) {
 						macro_file = true;
@@ -454,7 +445,7 @@ void scan_office_open_xml_api(
 							embedded_doc ||
 							macro_file
 						)
-					{	
+					{
 
 						int x;
 						const void *buff;
@@ -465,7 +456,7 @@ void scan_office_open_xml_api(
 							x = archive_read_data_block(a, &buff, &lsize, &offset);
 
 							if (x == ARCHIVE_EOF) {
-								
+
 								if (recurs_threshold_passed(iteration_counter)) {
 									free(fname);
 									if (final_buff) free(final_buff);
@@ -475,27 +466,27 @@ void scan_office_open_xml_api(
 								final_buff[final_size] = 0;
 								int elf_type = get_content_type (final_buff, final_size);
 								ssp_local->file_type = elf_type;
-								
+
 								increment_recur_counter();
-								
+
 								////////////////////////////////////////////////////////////////////
 								/*
 								 * embedded data within the office open xml doc
-								 * 
+								 *
 								 * if the detected type is officex (open xml) itself
 								 * then make a recursive call back into this same
 								 * function. otherwise pass the data over to the
 								 * callback function for content scanning
-								 * 
+								 *
 								 */
 								if (embedded_doc || macro_file) {
-										
+
 									ssp_local->buffer = final_buff;
 									ssp_local->buffer_length = final_size;
-									
+
 									int lf_type = get_content_type (final_buff, final_size);
 									ssp_local->file_type = lf_type;
-									
+
 									// ms-office open xml inside open xml
 									if (is_type_officex(lf_type)) {
 
@@ -509,42 +500,42 @@ void scan_office_open_xml_api(
 												in_type_of_scan);
 
 									} else {
-										
+
 										if (macro_file) {
 											snprintf (ssp_local->scan_type, sizeof(ssp_local->scan_type), "%s (%s) %s", type_of_scan[in_type_of_scan], "Macro file: \"vbaProject.bin\"", "embedded in an Office Open XML file");
 										} else {
 											snprintf (ssp_local->scan_type, sizeof(ssp_local->scan_type), "%s (%s) %s", type_of_scan[in_type_of_scan], get_content_type_string (lf_type), "embedded in an Office Open XML file");
 										}
-										
+
 										snprintf (ssp_local->parent_file_name, sizeof(ssp_local->parent_file_name), "%s", parent_file_name);
-	
+
 										cb((void *)ssp_local, oxml_ssr_list, fname);
-									
+
 									}
-									
+
 								} // end if (embedded_doc || macro_file)
 								////////////////////////////////////////////////////////////////////
-								
+
 								// non-embedded data ...
-								
+
 								/*
 								 * strip out the xml cruft so that scanning is
 								 * focused on the actual text
-								 * 
+								 *
 								 */
 								std::string ss = strip_office_open_xml(std::string((const char *)final_buff), oox_type);
-								
+
 								/*
 								 * need buffer in hex to make sure we
 								 * bypass certain elements of data we
 								 * are getting but do not want.
-								 * 
+								 *
 								 * keep this tight in case we are dealing
 								 * with a large data set. get_buf_hex
 								 * terminates the destination buffer so
 								 * in this case hexStr should be properly
 								 * terminated
-								 * 
+								 *
 								 */
 								char hexStr[9];
 								get_buf_hex(hexStr, (ss.substr (0,4)).c_str(), 4);
@@ -554,12 +545,12 @@ void scan_office_open_xml_api(
 									//std::cout << ss << std::endl;
 									// this is where we call scans against
 									// the data in ss
-									
+
 									int lf_type = get_content_type ((const uint8_t *)ss.c_str(), ss.length());
 									ssp_local->file_type = lf_type;
 									ssp_local->buffer = (const uint8_t *)ss.c_str();
 									ssp_local->buffer_length = ss.length();
-									
+
 									if (src)
 										snprintf (ssp_local->scan_type, sizeof(ssp_local->scan_type), "%s %s %s", type_of_scan[in_type_of_scan], "(Office Open XML)", src);
 									else
@@ -570,7 +561,7 @@ void scan_office_open_xml_api(
 
 									ssp_local->buffer = NULL;
 									ssp_local->buffer_length = 0;
-									
+
 								}
 
 								// reset
@@ -579,18 +570,18 @@ void scan_office_open_xml_api(
 								break;
 
 							} else if (x == ARCHIVE_OK) {
-								
+
 								final_size += lsize;
 								// extra byte final_size + 1 is for the guard byte
 								final_buff = (uint8_t*) realloc (final_buff, final_size + 1);
 								assert(final_buff);
 								assert(offset + lsize <= final_size);
 								memcpy(final_buff + offset, buff, lsize);
-								
+
 							} else {
-								
+
 								break;
-								
+
 							} // end if (x == ARCHIVE_OK)
 						} // end for loop
 					} // end a bunch of if oox_type
@@ -600,7 +591,7 @@ void scan_office_open_xml_api(
 		} // end for loop
 		if (final_buff)
 			free(final_buff);
-	} // end if r >= 0 
+	} // end if r >= 0
 cleanup_archive:
 	// clean up libarchive resources
 	archive_read_close(a);
@@ -622,22 +613,20 @@ void yara_cb (void *cookie, std::list<security_scan_results_t> *ssr_list, const 
 {
 	/*
 	 * yara call back
-	 * 
+	 *
 	 * this should be the only spot that makes calls out
-	 * directly to the bayshore yara wrapper 
+	 * directly to the bayshore yara wrapper
 	 */
-	if (DEBUG)
-		std::cout << DEBUG_PREFIX << IN_FUNC << __FUNCTION__ << std::endl;
-	
+
 	security_scan_parameters_t *ssp_local = (security_scan_parameters_t *)cookie;
-	
+
 	char local_api_yara_results[MAX_YARA_RES_BUF + 1024];
 	size_t local_api_yara_results_len = 0;
 	/*
 	 * to use this API the buffer passed in to param 4 (local_api_yara_results)
 	 * must be at least MAX_YARA_RES_BUF + 1024 in size. This is defined in
 	 * bayshore_yara_wrapper.h and extended by 1024 in bayshore_yara_wrapper.c
-	 * 
+	 *
 	 * first check for a native yara compiled rules struct,
 	 * if it exists call the wrapper API with it instead of
 	 * an actual ruleset file name
@@ -645,14 +634,14 @@ void yara_cb (void *cookie, std::list<security_scan_results_t> *ssr_list, const 
 
     //used to populate local_api_yara_results if there is a hit
 	if (ssp_local->rules) {
-		
+
 		bayshore_yara_wrapper_yrrules_api(
 				(uint8_t*)ssp_local->buffer,
 				ssp_local->buffer_length,
 				ssp_local->rules,
 				local_api_yara_results,
 				&local_api_yara_results_len);
-			
+
 	    // populate ssr/ssr_list whether there's a hit or not
 		security_scan_results_t ssr;
 		// populate struct elements
@@ -666,53 +655,53 @@ void yara_cb (void *cookie, std::list<security_scan_results_t> *ssr_list, const 
 			std::string sfname(ssp_local->parent_file_name, sspl_sz);
 			ssr.parent_file_name = sfname;
 		}
-				
+
 		if (child_file_name) {
 			std::string schfname(child_file_name);
 			ssr.child_file_name = schfname;
 		}
-	
+
 		char *output = str2md5((const char *)ssp_local->buffer, ssp_local->buffer_length);
 		if (output) {
 			memcpy (ssr.file_signature_md5, output, 33);
 			free(output);
 		}
-	
+
 		ssr_list->push_back(ssr);
-		
+
 	} else {
-        
+
 		bayshore_yara_wrapper_api(
 				(uint8_t*)ssp_local->buffer,
 				ssp_local->buffer_length,
 				ssp_local->yara_ruleset_filename,
 				local_api_yara_results,
 				&local_api_yara_results_len);
-			
+
 		security_scan_results_t ssr;
 		// populate struct elements
 		ssr.file_scan_type = ssp_local->scan_type;
 		std::string sres(local_api_yara_results, local_api_yara_results_len);
 		ssr.file_scan_result = sres;
 		ssr.file_size = ssp_local->buffer_length;
-				
+
 		size_t sspl_sz = strlen(ssp_local->parent_file_name);
 		if (sspl_sz > 0) {
 			std::string sfname(ssp_local->parent_file_name, sspl_sz);
 			ssr.parent_file_name = sfname;
 		}
-				
+
 		if (child_file_name) {
 			std::string schfname(child_file_name);
 			ssr.child_file_name = schfname;
 		}
-	
+
 		char *output = str2md5((const char *)ssp_local->buffer, ssp_local->buffer_length);
 		if (output) {
 			memcpy (ssr.file_signature_md5, output, 33);
 			free(output);
 		}
-	
+
 		ssr_list->push_back(ssr);
 	}
 
@@ -737,17 +726,15 @@ void scan_content (
 		int in_type_of_scan
 		)
 {
-	if (DEBUG)
-		std::cout << DEBUG_PREFIX << IN_FUNC << __FUNCTION__ << std::endl;
-	
+
 	iteration_counter = 0;
-	
+
 	int lin_type_of_scan = -1;
 	if (in_type_of_scan < sizeof(type_of_scan) / sizeof(type_of_scan[in_type_of_scan]))
 		lin_type_of_scan = in_type_of_scan;
 	else
 		lin_type_of_scan = 0;
-	
+
 	scan_content2(buf, sz, rules, ssr_list, parent_file_name, cb, lin_type_of_scan);
 }
 
@@ -766,9 +753,7 @@ void scan_content (
 		int in_type_of_scan
 		)
 {
-	if (DEBUG)
-		std::cout << DEBUG_PREFIX << IN_FUNC << __FUNCTION__ << std::endl;
-	
+
 	if (rule_file) {
 		YR_RULES* rules = bayshore_yara_preprocess_rules (rule_file);
 		if (rules) {
@@ -794,43 +779,41 @@ void scan_content2 (
 		int in_type_of_scan
 		)
 {
-	if (DEBUG)
-		std::cout << DEBUG_PREFIX << IN_FUNC << __FUNCTION__ << std::endl;
-	
+
 	if (buf) {
-	
+
 		/////////////////////////////////////////////////////
 		/*
 		 * construct the security_scan_parameters_t
 		 * struct to pass to the call back funcs
-		 * 
+		 *
 		 * right here populate the rule_file_name (yara)
 		 * and the parent_file_name
-		 * 
+		 *
 		 * later on, based on detected type, populate
 		 * the buffer to be analyzed and its respective
 		 * size (length)
-		 * 
+		 *
 		 */
 		security_scan_parameters_t ssp;
-		
+
 		if (in_type_of_scan == 1) {
 			if (rules)
 				ssp.rules = rules;
 		}
 		snprintf (ssp.parent_file_name, sizeof(ssp.parent_file_name), "%s", parent_file_name);
 		/////////////////////////////////////////////////////
-				
+
 		int buffer_type = get_content_type (buf, sz);
 		//std::cout << buffer_type << std::endl;
 		bool is_buf_archive = is_type_archive(buffer_type);
 
 		// archive
 		if (is_buf_archive) {
-			
+
 			if (recurs_threshold_passed(iteration_counter))
 				return;
-			
+
 			increment_recur_counter();
 			/*
 			 * intercept gzip compression and handle it
@@ -840,17 +823,17 @@ void scan_content2 (
 				// gunzip the data
 				ZlibInflator_t myzl;
 				myzl.Ingest ((uint8_t *)buf, sz);
-				
+
 				if (myzl.single_result.data && myzl.single_result.used) {
-					
+
 					int lf_type = get_content_type (myzl.single_result.data, myzl.single_result.used);
-        
+
 					std::string tmpfname = std::string(parent_file_name);
-					
+
 					ssp.buffer = myzl.single_result.data;
 					ssp.buffer_length = myzl.single_result.used;
 					ssp.file_type = lf_type;
-		
+
 					/*
 					 * cases like tar.gz, this would be the gunzipped
 					 * tarball
@@ -858,7 +841,7 @@ void scan_content2 (
 					if (is_type_archive(lf_type)) {
 
 						snprintf (ssp.scan_type, sizeof(ssp.scan_type), "%s (%s) inside GZIP Archive file", type_of_scan[in_type_of_scan], get_content_type_string (lf_type));
-						
+
 						cb((void *)&ssp, ssr_list, (remove_file_extension(tmpfname)).c_str());
 
 						scan_content2 (
@@ -869,7 +852,7 @@ void scan_content2 (
 								(remove_file_extension(std::string(parent_file_name))).c_str(),
 								cb,
 								in_type_of_scan);
-						
+
 					// pdf inside gzip
 		            } else if (is_type_pdf(lf_type)) {
 
@@ -880,7 +863,7 @@ void scan_content2 (
 								(remove_file_extension(tmpfname)).c_str(),
 								cb,
 								in_type_of_scan);
-						
+
 					// ms-office open xml inside gzip
 					} else if (is_type_officex(lf_type)) {
 
@@ -892,44 +875,44 @@ void scan_content2 (
 								false,
 								cb,
 								in_type_of_scan);
-	
+
 					} else {
-						
+
 						snprintf (ssp.scan_type, sizeof(ssp.scan_type), "%s (%s) inside GZIP Archive file", type_of_scan[in_type_of_scan], get_content_type_string (lf_type));
-						
+
 						cb((void *)&ssp, ssr_list, (remove_file_extension(tmpfname)).c_str());
-		
+
 					}
 				} // end if (myzl.single_result.data && myzl.single_result.used)
-				
+
 			} else if (is_type_bzip2(buffer_type)) {
-				
+
 				/*
 				 * intercept bzip2 compression and handle it
 				 * outside of libarchive
 				 */
-                              
+
                 BZlibInflator_t mybzl;
                 mybzl.bzdecomp((uint8_t*)buf,sz);
-                
+
                 if (mybzl.bzsingle_result.data && mybzl.bzsingle_result.used) {
-					
+
 					int lf_type = get_content_type (mybzl.bzsingle_result.data, mybzl.bzsingle_result.used);
-					
+
 					std::string tmpfname = std::string(parent_file_name);
-					
+
 					ssp.buffer = mybzl.bzsingle_result.data;
 					ssp.buffer_length = mybzl.bzsingle_result.used;
 					ssp.file_type = lf_type;
-		            
+
 					/*
 					 * cases like tar.bz, this would be the bunzipped
 					 * tarball
 					 */
 					if (is_type_archive(lf_type)) {
-						
+
                         snprintf (ssp.scan_type, sizeof(ssp.scan_type), "%s (%s) inside BZIP2 Archive file", type_of_scan[in_type_of_scan], get_content_type_string (lf_type));
-						
+
 						cb((void *)&ssp, ssr_list, (remove_file_extension(tmpfname)).c_str());
 
 						scan_content2 (
@@ -940,7 +923,7 @@ void scan_content2 (
 								(remove_file_extension(std::string(parent_file_name))).c_str(),
 								cb,
 								in_type_of_scan);
-						
+
 					// pdf inside bzip2
 		            } else if (is_type_pdf(lf_type)) {
 
@@ -951,7 +934,7 @@ void scan_content2 (
 								(remove_file_extension(tmpfname)).c_str(),
 								cb,
 								in_type_of_scan);
-						
+
 					// ms-office open xml inside bzip2
 					} else if (is_type_officex(lf_type)) {
 
@@ -963,21 +946,21 @@ void scan_content2 (
 								false,
 								cb,
 								in_type_of_scan);
-                        
-	
+
+
 					} else {
-						
+
 						snprintf (ssp.scan_type, sizeof(ssp.scan_type), "%s (%s) inside BZIP2 Archive file", type_of_scan[in_type_of_scan], get_content_type_string (lf_type));
-						
+
 						cb((void *)&ssp, ssr_list, (remove_file_extension(tmpfname)).c_str());
-		
+
 					}
 				} // end if (mybzl.bzsingle_result.data && mybzl.bzsingle_result.used)
-				
-                
-				
+
+
+
 			} else {
-			
+
 				// prep stuff for libarchive
 				struct archive *a = archive_read_new();
 				assert(a);
@@ -986,7 +969,7 @@ void scan_content2 (
 
 				archive_read_support_format_all(a);
 				archive_read_support_format_raw(a);
-				
+
 #if ARCHIVE_VERSION_NUMBER < 3000000
 				archive_read_support_compression_all(a);
 #elsif ARCHIVE_VERSION_NUMBER >= 3000000
@@ -994,134 +977,128 @@ void scan_content2 (
 #endif
 
 				r = archive_read_open_memory(a, (uint8_t *)buf, sz);
-				
+
 				if (r < 0) {
-		
+
 				} else {
 					/*
 					 * libarchive understood the archival tech in
 					 * place with the data in buffer file_content ...
 					 */
-					
+
 					// final sets of data
 					uint8_t *final_buff = (uint8_t*) malloc (2048);
 					final_buff[0] = 0;
 					size_t final_size = 0;
-		
+
 					for (;;) {
 						r = archive_read_next_header(a, &entry);
-						
+
 						if (r == ARCHIVE_EOF)
 							break;
-						
+
 						if (r != ARCHIVE_OK)
 							break;
-						
+
 						if (r < ARCHIVE_WARN)
 							break;
-						
+
 						if (archive_entry_size(entry) > 0) {
-							
+
 							char *fname = strdup(archive_entry_pathname(entry));
-		
+
 							int x;
 							const void *buff;
 							size_t lsize;
 							off64_t offset;
-		
+
 							for (;;) {
-								
+
 								x = archive_read_data_block(a, &buff, &lsize, &offset);
-		
+
 								// hit EOF so process constructed buffer
 								if (x == ARCHIVE_EOF) {
-									
+
 									if (recurs_threshold_passed(iteration_counter))
 										return;
-									
+
 									increment_recur_counter();
-		
+
 									final_buff[final_size] = 0;
 									int lf_type = get_content_type (final_buff, final_size);
-									
+
 									ssp.buffer = final_buff;
 									ssp.buffer_length = final_size;
 									ssp.file_type = lf_type;
 
 									// archive, make recursive call into scan_content
 									if (is_type_archive(lf_type)) {
-										
+
                                         snprintf (ssp.scan_type, sizeof(ssp.scan_type), "%s (%s) inside %s file", type_of_scan[in_type_of_scan], get_content_type_string (lf_type), archive_format_name(a));
 										snprintf (ssp.parent_file_name, sizeof(ssp.parent_file_name), "%s", parent_file_name);
-										
+
 										cb((void *)&ssp, ssr_list, fname ? fname : "");
 
 										scan_content2 (final_buff, final_size, rules, ssr_list, fname, cb, in_type_of_scan);
-										
+
 									// pdf
 									} else if (is_type_pdf(lf_type)) {
-										
+
 										char scan_src [100];
 										snprintf (scan_src, sizeof(scan_src), " inside %s file", archive_format_name(a));
 										snprintf (ssp.parent_file_name, sizeof(ssp.parent_file_name), "%s", parent_file_name);
-										/*
-										if (DEBUG) {
-											std::cout << "[DEBUG]PDF detected inside archive" << std::endl;
-											std::cout << "[DEBUG]SCAN SRC: " << scan_src << std::endl;
-											std::cout << "[DEBUG]PARENT FILE NAME: " << parent_file_name << std::endl;
-										}
-										*/
+
 										scan_pdf_api((void *)&ssp, ssr_list, scan_src, fname ? fname : "", cb, in_type_of_scan);
-										
+
 									// ms-office open xml inside archive
 									} else if (is_type_officex(lf_type) || is_type_open_document_format(lf_type)) {
-									
+
 										char scan_src [100];
 										snprintf (scan_src, sizeof(scan_src), "inside %s file", archive_format_name(a));
 										snprintf (ssp.parent_file_name, sizeof(ssp.parent_file_name), "%s", parent_file_name);
 
 										scan_office_open_xml_api((void *)&ssp, ssr_list, scan_src, fname ? fname : "", false, cb, in_type_of_scan);
-										
+
 									} else {
-										
+
 										snprintf (ssp.scan_type, sizeof(ssp.scan_type), "%s (%s) inside %s file", type_of_scan[in_type_of_scan], get_content_type_string (lf_type), archive_format_name(a));
 										snprintf (ssp.parent_file_name, sizeof(ssp.parent_file_name), "%s", parent_file_name);
-										
+
 										cb((void *)&ssp, ssr_list, fname ? fname : "");
-						
+
 									}
-									
+
 									// reset to 0
 									final_size = 0;
 									break;
-									
+
 								} else if (x == ARCHIVE_OK) {
-		
+
 									/*
-									 * good to go ... 
-									 * 
+									 * good to go ...
+									 *
 									 * extend final_buffer, write data to the
 									 * end of it, and terminate back inside of
 									 * if (x == ARCHIVE_EOF)
 									 */
-									
+
 									final_size += lsize;
 									// extra byte final_size + 1 is for the guard byte
 									final_buff = (uint8_t*) realloc (final_buff, final_size + 1);
 									assert(final_buff);
 									assert(offset + lsize <= final_size);
 									memcpy(final_buff + offset, buff, lsize);
-									
+
 								} else if (x == ARCHIVE_FAILED) {
-									
+
 									increment_recur_counter();
 									increment_archive_failure_counter();
 									break;
-									
+
 								} else {
-									
+
 									break;
-									
+
 								} // end if else if
 							} // end for
 							if (fname)
@@ -1131,25 +1108,25 @@ void scan_content2 (
 					if (final_buff)
 						free(final_buff);
 				} // end if else
-		
+
 				// free up libarchive resources
 				archive_read_close(a);
 				archive_read_free(a);
 			} // end if gzip else
-		
+
 		} else { // not an archive
 
 			/*
 			 * if we are here then we are not dealing
 			 * with an archive in the buffer, i.e. not
-			 * a zip or gzip or tarball 
+			 * a zip or gzip or tarball
 			 */
-			
+
 			if (recurs_threshold_passed(iteration_counter))
 				return;
-			
+
 			increment_recur_counter();
-			
+
 			ssp.buffer = buf;
 			ssp.buffer_length = sz;
 			ssp.file_type = buffer_type;
@@ -1161,18 +1138,18 @@ void scan_content2 (
 			} else if (is_type_officex(buffer_type) || is_type_open_document_format(buffer_type)) {
 
 				scan_office_open_xml_api((void *)&ssp, ssr_list, "", parent_file_name ? parent_file_name : "", false, cb, in_type_of_scan);
-				
+
 			} else {
-			
+
 				snprintf (ssp.scan_type, sizeof(ssp.scan_type), "%s (%s)", type_of_scan[in_type_of_scan], get_content_type_string (buffer_type));
-				
+
 				cb((void *)&ssp, ssr_list, "");
-			
+
 			}
-		
+
 		} // end if else - archive
-		
-		
+
+
 		/*
 		std::cout << "FAILURES: " << archive_failure_counter << std::endl;
 		std::cout << "ITERATIONS: " << iteration_counter << std::endl;
@@ -1180,18 +1157,18 @@ void scan_content2 (
 		*/
 		/////////////////////////////////////////////////////
 		if (get_failure_percentage() > 90) {
-			
+
 			security_scan_results_t ssr;
 			// populate struct elements
 			ssr.file_scan_type = "Archive Anomaly Scan";
-			
+
 			ssr.file_scan_result = "Anomalies present in Archive (possible Decompression Bomb)";
-			
+
 			if (parent_file_name) {
 				std::string sfname(parent_file_name);
 				ssr.parent_file_name = sfname;
 			}
-	
+
 			char *output = str2md5((const char *)buf, sz);
 			if (output) {
 				memcpy (ssr.file_signature_md5, output, 33);
@@ -1202,4 +1179,3 @@ void scan_content2 (
 		/////////////////////////////////////////////////////
 	} // end if (buf)
 }
-

--- a/bayshore_content_scan.cpp
+++ b/bayshore_content_scan.cpp
@@ -254,8 +254,10 @@ void scan_pdf_api(void *cookie,
 		std::cout << DEBUG_PREFIX << IN_FUNC << __FUNCTION__ << std::endl;
 	
 	security_scan_parameters_t *ssp_local = (security_scan_parameters_t *)cookie;
+	assert(ssp_local);
 	
-	size_t src_len = strlen(src);
+	size_t src_len = 0;
+	if (src) src_len = strlen(src);
 	
 	/////////////////////////////////////////////////////////
 	/*
@@ -337,10 +339,12 @@ void scan_office_open_xml_api(
 
 	cb(cookie, oxml_ssr_list, parent_file_name ? parent_file_name : "");
 
-	if (src == NULL) return; //TODO: Indicate the condition
 
 	security_scan_parameters_t *ssp_local = (security_scan_parameters_t *)cookie;
-	size_t src_len = strlen(src);
+	assert(ssp_local);
+
+	size_t src_len = 0;
+	if (NULL!=src) src_len = strlen(src);
 	
 	struct archive *a = archive_read_new();
 	assert(a);

--- a/bayshore_content_scan.cpp
+++ b/bayshore_content_scan.cpp
@@ -3,7 +3,7 @@
  * YEXTEND: Help for YARA users.
  * This file is part of yextend.
  *
- * Copyright (c) 2014-2017, Bayshore Networks, Inc.
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that

--- a/bayshore_content_scan.cpp
+++ b/bayshore_content_scan.cpp
@@ -278,6 +278,7 @@ void scan_pdf_api(void *cookie,
 	std::string str_buf;
 	auto pdf_temp = pdfparser::PdfToText((uint8_t *)ssp_local->buffer, ssp_local->buffer_length);
 	str_buf = std::string (pdf_temp.begin(), pdf_temp.end());
+	std::cout << "START RODRIGO" << std::endl << str_buf << "END RODRIGO" << std::endl;
 
 	/*
 	 * 2.
@@ -309,7 +310,7 @@ void scan_pdf_api(void *cookie,
 	// These can no longer be used.
 	ssp_local->buffer = NULL;
 	ssp_local->buffer_length = 0;
-	
+
 }
 
 

--- a/bayshore_content_scan.h
+++ b/bayshore_content_scan.h
@@ -3,21 +3,21 @@
  * YEXTEND: Help for YARA users.
  * This file is part of yextend.
  *
- * Copyright (c) 2014-2017, Bayshore Networks, Inc.
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
  * following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
  * following disclaimer in the documentation and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
  * products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
@@ -47,10 +47,10 @@
 
 /*
  * Notes:
- * 
+ *
  * The calling side (the one using this lib) needs to understand
  * the architecture at hand. A call to the scan_X API's requires:
- * 
+ *
  * 		1. buffer
  * 		2. buffer length
  * 		3. rule file (only used by the yara callback - can be NULL or "")
@@ -61,19 +61,19 @@
  * 		7. int representing type of scan, types:
  * 			A. "Generic" - index 0 (for internal use only)
  * 			B. "Yara Scan" - index 1
- * 
+ *
  */
 
 // structs
 struct security_scan_results_t {
-	
+
 	std::string file_scan_type;
 	std::string file_scan_result;
 	char file_signature_md5[33];
 	std::string parent_file_name;
 	std::string child_file_name;
 	size_t file_size;
-	
+
 	security_scan_results_t()
 	{
 		file_scan_type = "";

--- a/dockerize/README.md
+++ b/dockerize/README.md
@@ -1,0 +1,60 @@
+This folder contains useful files for setting up docker development
+environment and allowing yextend to be built under docker.
+
+The simplest way is to use Ubuntu Xenial and setup docker build
+environment.
+
+These are the steps - assuming you have shell in this folder:
+
+* $ docker build --build-arg user=$USER --build-arg uid=`id -u $USER` --build-arg gid=`id -g $USER` -f dockerfile-amd64-ubuntu-xenial . -t yextend-ubuntu-xenial
+
+This command builds docker environment using Ubuntu Xenial (16.04)
+Alternatively - you can run the provided build-container.sh script:
+
+* $ ./build-container.sh
+
+This will build the container for your host's environment.
+
+To run the docker container - issue the command:
+
+* docker run -it --hostname yextend-build -v $HOME/src/yextend:/yextend yextend-ubuntu-xenial
+
+If your host's OS is different than Ubuntu Xenial - adjust for your
+host's environment.
+
+Assuming the yextend project has been cloned to $HOME/src/yextend.
+You are presented with a docker shell:
+
+* bayshore@yextend-build:/$
+
+The docker contained maps your $HOME/src/yextend folder to /yextend
+In order to build yextend - issue the following commands:
+
+* bayshore@yextend-build:/$ cd /yextend/
+* bayshore@yextend-build:~$ ./autogen.sh
+* bayshore@yextend-build:~$ ./configure && make
+
+This will build yextend in your $HOME/src/yextend folder.
+If you wish to run the built-in unit tests - issue:
+
+* bayshore@yextend-build:~$ make unittests
+
+Example output:
+* cd test; nosetests -s; cd ..
+* ....................
+* ----------------------------------------------------------------------
+* Ran 20 tests in 0.004s
+* 
+* OK
+
+
+BayshoreNetworks provides docker build files for:
+
+* Ubuntu Xenial - dockerfile-amd64-ubuntu-xenial
+* Ubuntu Artful - dockerfile-amd64-ubuntu-artful
+* Debian Stretch - dockerfile-amd64-debian-stretch
+* Debian Stretch - dockerfile-amd64-debian-jessie
+* Raspberry Pi - dockerfile-armhf-raspbian-stretch
+* HardKernel Odroid C1 - dockerfile-armhf-ubuntu-xenial
+
+If you would like additional docker files - please contact BayshoreNetworks.

--- a/dockerize/README.md
+++ b/dockerize/README.md
@@ -30,9 +30,9 @@ You are presented with a docker shell:
 The docker contained maps your $HOME/src/yextend folder to /yextend
 In order to build yextend - issue the following commands:
 
-* bayshore@yextend-build:/$ cd /yextend/
-* bayshore@yextend-build:~$ ./autogen.sh
-* bayshore@yextend-build:~$ ./configure && make
+	bayshore@yextend-build:/$ cd /yextend/
+	bayshore@yextend-build:~$ ./autogen.sh
+	bayshore@yextend-build:~$ ./configure && make
 
 This will build yextend in your $HOME/src/yextend folder.
 If you wish to run the built-in unit tests - issue:
@@ -40,12 +40,12 @@ If you wish to run the built-in unit tests - issue:
 * bayshore@yextend-build:~$ make unittests
 
 Example output:
-* cd test; nosetests -s; cd ..
-* ....................
-* ----------------------------------------------------------------------
-* Ran 20 tests in 0.004s
-* 
-* OK
+	cd test; nosetests -s; cd ..
+	....................
+	----------------------------------------------------------------------
+	Ran 20 tests in 0.004s
+	 
+	OK
 
 
 BayshoreNetworks provides docker build files for:
@@ -54,6 +54,7 @@ BayshoreNetworks provides docker build files for:
 * Ubuntu Artful - dockerfile-amd64-ubuntu-artful
 * Debian Stretch - dockerfile-amd64-debian-stretch
 * Debian Stretch - dockerfile-amd64-debian-jessie
+* Fedora Core 27 - dockerfile-amd64-fedora
 * Raspberry Pi - dockerfile-armhf-raspbian-stretch
 * HardKernel Odroid C1 - dockerfile-armhf-ubuntu-xenial
 

--- a/dockerize/build-container.sh
+++ b/dockerize/build-container.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+arch=`dpkg --print-architecture`
+id=`lsb_release -si`
+distr=`lsb_release -sc`
+user=`whoami`
+docker build --build-arg user=$user --build-arg uid=`id -u $user` --build-arg gid=`id -g $user` -f dockerfile-${arch}-${id,,}-${distr} . -t yextend-${id,,}-${distr}
+
+exit 0

--- a/dockerize/dockerfile-amd64-debian-jessie
+++ b/dockerize/dockerfile-amd64-debian-jessie
@@ -1,0 +1,40 @@
+FROM debian:jessie
+LABEL vendor="Bayshore Networks" \
+	com.bayshorenetworks.version="1.0" \
+	com.bayshorenetworks.version.is-production="yes" \
+	com.bayshorenetworks.release-date="2017-12-01"
+ENV TERM vt102
+ENV HOME /yextend
+ARG user=bayshore
+ARG uid=1000
+ARG gid=1000
+RUN apt-get update && apt-get install -y \
+		wget \
+		make \
+		pkg-config \
+		autoconf \
+		zlib1g-dev \
+		g++ \
+		autoconf \
+		libtool \
+		zlib1g-dev \
+		libssl-dev \
+		libbz2-dev \
+		libarchive-dev \
+		libpcre3-dev \
+		uuid-dev \
+		poppler-utils \
+		python-nose  \
+	&& rm -rf /var/lib/apt/lists/*
+RUN wget -O /tmp/v3.7.0.tar.gz https://github.com/VirusTotal/yara/archive/v3.7.0.tar.gz && \
+	cd /tmp && \
+	tar xfz v3.7.0.tar.gz && \
+	cd yara-3.7.0 && \
+	./bootstrap.sh && \
+	./configure --prefix=/usr && \
+	make && make install && \
+	rm -rf v3.7.0*
+ENV YEXTEND_HOME /yextend/
+RUN groupadd -g $gid $user && \
+	useradd -u $uid -g $gid $user
+USER $user

--- a/dockerize/dockerfile-amd64-debian-stretch
+++ b/dockerize/dockerfile-amd64-debian-stretch
@@ -1,0 +1,40 @@
+FROM debian:stretch
+LABEL vendor="Bayshore Networks" \
+	com.bayshorenetworks.version="1.0" \
+	com.bayshorenetworks.version.is-production="yes" \
+	com.bayshorenetworks.release-date="2017-12-01"
+ENV TERM vt102
+ENV HOME /yextend
+ARG user=bayshore
+ARG uid=1000
+ARG gid=1000
+RUN apt-get update && apt-get install -y \
+		wget \
+		make \
+		pkg-config \
+		autoconf \
+		zlib1g-dev \
+		g++ \
+		autoconf \
+		libtool \
+		zlib1g-dev \
+		libssl-dev \
+		libbz2-dev \
+		libarchive-dev \
+		libpcre3-dev \
+		uuid-dev \
+		poppler-utils \
+		python-nose  \
+	&& rm -rf /var/lib/apt/lists/*
+RUN wget -O /tmp/v3.7.0.tar.gz https://github.com/VirusTotal/yara/archive/v3.7.0.tar.gz && \
+	cd /tmp && \
+	tar xfz v3.7.0.tar.gz && \
+	cd yara-3.7.0 && \
+	./bootstrap.sh && \
+	./configure --prefix=/usr && \
+	make && make install && \
+	rm -rf v3.7.0*
+ENV YEXTEND_HOME /yextend/
+RUN groupadd -g $gid $user && \
+	useradd -u $uid -g $gid $user
+USER $user

--- a/dockerize/dockerfile-amd64-fedora
+++ b/dockerize/dockerfile-amd64-fedora
@@ -1,0 +1,38 @@
+FROM fedora:latest
+LABEL vendor="Bayshore Networks" \
+	com.bayshorenetworks.version="1.0" \
+	com.bayshorenetworks.version.is-production="yes" \
+	com.bayshorenetworks.release-date="2017-12-01"
+ENV TERM vt102
+ENV HOME /yextend
+ARG user=bayshore
+ARG uid=1000
+ARG gid=1000
+RUN dnf -y install \
+		wget \
+		make \
+		pkgconf-pkg-config \
+		autoconf \
+		gcc-c++ \
+		libtool \
+		zlib-devel \
+		bzip2-devel \
+		openssl-devel \
+		libarchive-devel \
+		pcre-devel \
+		libuuid-devel \
+		poppler-utils \
+		python-nose
+RUN wget -O /tmp/v3.7.0.tar.gz https://github.com/VirusTotal/yara/archive/v3.7.0.tar.gz && \
+	cd /tmp && \
+	tar xfz v3.7.0.tar.gz && \
+	cd yara-3.7.0 && \
+	./bootstrap.sh && \
+	./configure --prefix=/usr && \
+	make && make install && \
+	rm -rf v3.7.0*
+ENV YEXTEND_HOME /yextend/
+RUN groupadd -g $gid $user && \
+	useradd -u $uid -g $gid $user
+USER $user
+CMD ["/bin/bash"]

--- a/dockerize/dockerfile-amd64-ubuntu-artful
+++ b/dockerize/dockerfile-amd64-ubuntu-artful
@@ -1,0 +1,40 @@
+FROM ubuntu:17.10
+LABEL vendor="Bayshore Networks" \
+	com.bayshorenetworks.version="1.0" \
+	com.bayshorenetworks.version.is-production="yes" \
+	com.bayshorenetworks.release-date="2017-12-01"
+ENV TERM vt102
+ENV HOME /yextend
+ARG user=bayshore
+ARG uid=1000
+ARG gid=1000
+RUN apt-get update && apt-get install -y \
+		wget \
+		make \
+		pkg-config \
+		autoconf \
+		zlib1g-dev \
+		g++ \
+		autoconf \
+		libtool \
+		zlib1g-dev \
+		libssl-dev \
+		libbz2-dev \
+		libarchive-dev \
+		libpcre3-dev \
+		uuid-dev \
+		poppler-utils \
+		python-nose  \
+	&& rm -rf /var/lib/apt/lists/*
+RUN wget -O /tmp/v3.7.0.tar.gz https://github.com/VirusTotal/yara/archive/v3.7.0.tar.gz && \
+	cd /tmp && \
+	tar xfz v3.7.0.tar.gz && \
+	cd yara-3.7.0 && \
+	./bootstrap.sh && \
+	./configure --prefix=/usr && \
+	make && make install && \
+	rm -rf v3.7.0*
+ENV YEXTEND_HOME /yextend/
+RUN groupadd -g $gid $user && \
+	useradd -u $uid -g $gid $user
+USER $user

--- a/dockerize/dockerfile-amd64-ubuntu-xenial
+++ b/dockerize/dockerfile-amd64-ubuntu-xenial
@@ -1,0 +1,41 @@
+FROM ubuntu:16.04
+LABEL vendor="Bayshore Networks" \
+	com.bayshorenetworks.version="1.0" \
+	com.bayshorenetworks.version.is-production="yes" \
+	com.bayshorenetworks.release-date="2017-12-01"
+ENV TERM vt102
+ENV HOME /yextend
+ARG user=bayshore
+ARG uid=1000
+ARG gid=1000
+RUN apt-get update && apt-get install -y \
+		wget \
+		make \
+		pkg-config \
+		autoconf \
+		zlib1g-dev \
+		g++ \
+		autoconf \
+		libtool \
+		zlib1g-dev \
+		libssl-dev \
+		libbz2-dev \
+		libarchive-dev \
+		libpcre3-dev \
+		uuid-dev \
+		poppler-utils \
+		python-nose  \
+	&& rm -rf /var/lib/apt/lists/*
+RUN wget -O /tmp/v3.7.0.tar.gz https://github.com/VirusTotal/yara/archive/v3.7.0.tar.gz && \
+	cd /tmp && \
+	tar xfz v3.7.0.tar.gz && \
+	cd yara-3.7.0 && \
+	./bootstrap.sh && \
+	./configure --prefix=/usr && \
+	make && make install && \
+	rm -rf v3.7.0*
+
+ENV YEXTEND_HOME /yextend/
+RUN groupadd -g $gid $user && \
+	useradd -u $uid -g $gid $user
+USER $user

--- a/dockerize/dockerfile-armhf-raspbian-stretch
+++ b/dockerize/dockerfile-armhf-raspbian-stretch
@@ -1,0 +1,43 @@
+FROM arm32v7/debian:stretch
+LABEL vendor="Bayshore Networks" \
+	com.bayshorenetworks.version="1.0" \
+	com.bayshorenetworks.version.is-production="yes" \
+	com.bayshorenetworks.release-date="2018-01-14"
+ENV HOME /yextend
+ENV TERM=vt102
+ARG user=bayshore
+ARG uid=1000
+ARG gid=1000
+RUN apt-get update && \
+    apt-get install -y \
+		wget \
+		pkg-config \
+		autoconf \
+		make \
+		zlib1g-dev \
+		g++ \
+		autoconf \
+		libtool \
+		zlib1g-dev \
+		libssl-dev \
+		libbz2-dev \
+		libarchive13 \
+		libarchive-dev \
+		libpcre3-dev \
+		uuid-dev \
+		poppler-utils \
+		python-nose \
+	&& rm -rf /var/lib/apt/lists/*
+RUN wget -O /tmp/v3.7.0.tar.gz https://github.com/VirusTotal/yara/archive/v3.7.0.tar.gz && \
+	cd /tmp && \
+	tar xfz v3.7.0.tar.gz && \
+	cd yara-3.7.0 && \
+	./bootstrap.sh && \
+	./configure --prefix=/usr && \
+	make && make install && \
+	rm -rf v3.7.0*
+
+ENV YEXTEND_HOME /yextend/
+RUN groupadd -g $gid $user && \
+	useradd -u $uid -g $gid $user
+USER $user

--- a/dockerize/dockerfile-armhf-ubuntu-xenial
+++ b/dockerize/dockerfile-armhf-ubuntu-xenial
@@ -1,0 +1,41 @@
+FROM armv7/armhf-ubuntu
+LABEL vendor="Bayshore Networks" \
+	com.bayshorenetworks.version="1.0" \
+	com.bayshorenetworks.version.is-production="yes" \
+	com.bayshorenetworks.release-date="2017-12-01"
+ENV TERM vt102
+ENV HOME /yextend
+ARG user=bayshore
+ARG uid=1000
+ARG gid=1000
+RUN apt-get update && apt-get install -y \
+		wget \
+		make \
+		pkg-config \
+		autoconf \
+		zlib1g-dev \
+		g++ \
+		autoconf \
+		libtool \
+		zlib1g-dev \
+		libssl-dev \
+		libbz2-dev \
+		libarchive-dev \
+		libpcre3-dev \
+		uuid-dev \
+		poppler-utils \
+		python-nose  \
+	&& rm -rf /var/lib/apt/lists/*
+RUN wget -O /tmp/v3.7.0.tar.gz https://github.com/VirusTotal/yara/archive/v3.7.0.tar.gz && \
+	cd /tmp && \
+	tar xfz v3.7.0.tar.gz && \
+	cd yara-3.7.0 && \
+	./bootstrap.sh && \
+	./configure --prefix=/usr && \
+	make && make install && \
+	rm -rf v3.7.0*
+
+ENV YEXTEND_HOME /yextend/
+RUN groupadd -g $gid $user && \
+	useradd -u $uid -g $gid $user
+USER $user

--- a/dockerize/dockerfile-armhf-ubuntu-xenial
+++ b/dockerize/dockerfile-armhf-ubuntu-xenial
@@ -1,8 +1,8 @@
-FROM armv7/armhf-ubuntu
+FROM arm32v7/ubuntu
 LABEL vendor="Bayshore Networks" \
-	com.bayshorenetworks.version="1.0" \
+	com.bayshorenetworks.version="1.1" \
 	com.bayshorenetworks.version.is-production="yes" \
-	com.bayshorenetworks.release-date="2017-12-01"
+	com.bayshorenetworks.release-date="2018-03-06"
 ENV TERM vt102
 ENV HOME /yextend
 ARG user=bayshore

--- a/libs/bayshore_file_type_detect.c
+++ b/libs/bayshore_file_type_detect.c
@@ -3,21 +3,21 @@
  * YEXTEND: Help for YARA users.
  * This file is part of yextend.
  *
- * Copyright (c) 2014-2017, Bayshore Networks, Inc.
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
  * following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
  * following disclaimer in the documentation and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
  * products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
@@ -142,7 +142,7 @@ int is_buffer_encrypted(const uint8_t* buf, size_t nL)
 {
 	/*
 	 * return:
-	 * 
+	 *
 	 * 1 = true
 	 * 0 = false
 	 */
@@ -187,7 +187,7 @@ void get_buffer_hex(char *dest, const char *src, int threshold, int *ispe)
 	int i;
 	//int offs = 0;
 	/*
-    	hex for PE\0\0 - identifier for a 
+    	hex for PE\0\0 - identifier for a
     	windows portable executable
 	 */
 	const char pestr[] = "50450000";
@@ -270,7 +270,7 @@ int is_text_buffer(const uint8_t *buf, size_t sz) {
 	 * detect that a buffer is pure ASCII text
 	 * in nature. This will have to suffice
 	 * for now
-	 * 
+	 *
 	 * 1 = ascii text
 	 * 0 = not ascii text
 	 */
@@ -413,7 +413,7 @@ int tokenize_yara_str(char *buf) {
 }
 
 int get_buffer_type(const uint8_t *buf, size_t sz) {
-	
+
 	int return_type = -1;
 
 	int zip_exception = -1;
@@ -433,7 +433,7 @@ int get_buffer_type(const uint8_t *buf, size_t sz) {
 
 	YR_RULES* rules = bayshore_yara_preprocess_rules (path);
 
-	/* 
+	/*
 	 * When calling bayshore_yara_wrapper_yrrules_api, the next-to-last parameter is a
 	 * pointer to a caller-supplied char buffer. The caller is required to ensure
 	 * that this buffer is at least MAX_YARA_RES_BUF bytes long.
@@ -480,11 +480,11 @@ int get_buffer_type(const uint8_t *buf, size_t sz) {
 	 * move on
 	 */
 	if (zip_exception != -1) {
-		
+
 		/*
 		 * differentiate between zip / jar by looking
 		 * for - META-INF/MANIFEST.MF
-		 * 
+		 *
 		 * this isn't perfect but should catch a high
 		 * percentage of jar file detection
 		 */
@@ -494,15 +494,15 @@ int get_buffer_type(const uint8_t *buf, size_t sz) {
 			/*
 			 * not a jar file so ....
 			 */
-			
+
 			if (zip_exception == 28) {
 				return 28;
 			}
-			
+
 			if (zip_exception == 50) {
 				return 50;
 			}
-			
+
 			if (zip_exception == 65534) {
 				return 65534;
 			}
@@ -525,7 +525,7 @@ int get_buffer_type(const uint8_t *buf, size_t sz) {
 	// we have php, or is it xml??
 	if (xml_exception != -1) {
 		char thesubstr[11];
-		// xml = len 10 in hex 
+		// xml = len 10 in hex
 		bayshoresubstring(0, 11, hex_str, thesubstr, sizeof thesubstr);
 		// it is xml
 		if (strncmp (thesubstr, "3c3f786d6c", 10) == 0) {
@@ -570,7 +570,7 @@ int get_buffer_type(const uint8_t *buf, size_t sz) {
 /*
  * 1 = true
  * 0 = false
- * 
+ *
  */
 
 // officex - docx, pptx, xslx
@@ -806,15 +806,15 @@ void get_buffer_type_str(int type, uint8_t *buf) {
 	 * this may not be cleanest way of doing this
 	 * (getting the text string of a detected file type)
 	 * but it seems fast enough
-	 * 
+	 *
 	 * I just hate maintaining this data set here
 	 * on top of the yara ruleset used for type
 	 * detection but this is the path of least
 	 * resistance at the moment ...
-	 * 
+	 *
 	 * The { case ... } code here was generated via
 	 * a py script run against the bayshore file
-	 * type detection yara ruleset 
+	 * type detection yara ruleset
 	 */
 	int the_len = 0;
 
@@ -1451,7 +1451,7 @@ void get_buffer_type_str(int type, uint8_t *buf) {
 		the_len = 0;
 		break;
 	}
-	buf[the_len] = '\0';    
+	buf[the_len] = '\0';
 }
 
 

--- a/libs/bayshore_file_type_detect.h
+++ b/libs/bayshore_file_type_detect.h
@@ -3,21 +3,21 @@
  * YEXTEND: Help for YARA users.
  * This file is part of yextend.
  *
- * Copyright (c) 2014-2017, Bayshore Networks, Inc.
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
  * following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
  * following disclaimer in the documentation and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
  * products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,

--- a/libs/bayshore_yara_wrapper.c
+++ b/libs/bayshore_yara_wrapper.c
@@ -3,21 +3,21 @@
  * YEXTEND: Help for YARA users.
  * This file is part of yextend.
  *
- * Copyright (c) 2014-2017, Bayshore Networks, Inc.
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
  * following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
  * following disclaimer in the documentation and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
  * products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
@@ -144,17 +144,17 @@ int bayshore_yara_handle_message(int message, YR_RULE* rule, void* data)
 	is_matching = (message == CALLBACK_MSG_RULE_MATCHING);
 
 	/*
-	 * if there is a match with a yara rule then concat the 
+	 * if there is a match with a yara rule then concat the
 	 * relevant meta-data to the variable yara_results
 	 */
 	if (is_matching)
 	{
 		char yara_meta_results[MAX_YARA_RES_BUF];
 		yara_meta_results[0] = 0;
-		
+
 		// assuming yara_results is a buffer and not a pointer
 		strncat (yara_results, rule->identifier, sizeof(yara_results)-strlen(yara_results)-1);
-		
+
 		if (show_meta) {
 			YR_META* meta;
 			//printf("[ ");
@@ -164,11 +164,11 @@ int bayshore_yara_handle_message(int message, YR_RULE* rule, void* data)
 					//strncat (yara_meta_results, ",", sizeof(yara_results)-strlen(yara_results)-1);
 					strncat (yara_meta_results, META_DELIM, sizeof(yara_results)-strlen(yara_results)-1);
 				}
-				
+
 				if (meta->type == META_TYPE_INTEGER) {
 					strncat (yara_meta_results, meta->identifier, sizeof(yara_meta_results)-strlen(yara_meta_results)-1);
 					strncat (yara_meta_results, "=", sizeof(yara_meta_results)-strlen(yara_meta_results)-1);
-					
+
 					char intstr[15];
 					//sprintf(intstr, "%d", meta->integer);
 					//sprintf(intstr, "%" PRId64, meta->integer);
@@ -177,7 +177,7 @@ int bayshore_yara_handle_message(int message, YR_RULE* rule, void* data)
 				} else if (meta->type == META_TYPE_BOOLEAN) {
 					strncat (yara_meta_results, meta->identifier, sizeof(yara_meta_results)-strlen(yara_meta_results)-1);
 					strncat (yara_meta_results, "=", sizeof(yara_meta_results)-strlen(yara_meta_results)-1);
-					
+
 					char intstr[15];
 					sprintf(intstr, "%s", meta->integer ? "true" : "false");
 					strncat (yara_meta_results, intstr, sizeof(yara_meta_results)-strlen(yara_meta_results)-1);
@@ -190,11 +190,11 @@ int bayshore_yara_handle_message(int message, YR_RULE* rule, void* data)
 			//printf("] ");
 		}
 		//printf("] ");
-		
+
 		int hit_cnt = 0;
 		char tmp_str_results[4096];
 		tmp_str_results[0] = 0;
-		
+
 		if (show_strings) {
 			YR_STRING* string;
 			yr_rule_strings_foreach(rule, string)
@@ -207,20 +207,20 @@ int bayshore_yara_handle_message(int message, YR_RULE* rule, void* data)
 					 * the string definition identifier from the yara rule,
 					 * where the target yara rule matched the data being
 					 * scanned/searched
-					 * 
-					 */					
+					 *
+					 */
 					char tmp_results[1024];
 			    	//sprintf(tmp_results, "0x%" PRIx64 ":%s-", match->base + match->offset, string->identifier);
 			    	//sprintf(tmp_results, "0x%lx:%s-", match->base + match->offset, string->identifier);
 					snprintf(tmp_results, sizeof(tmp_results), "0x%lx:%s-", match->base + match->offset, string->identifier);
 			    	strncat(tmp_str_results, tmp_results, sizeof(tmp_str_results)-strlen(tmp_str_results)-1);
-					
+
 					hit_cnt += 1;
 				}
 			}
 			//printf("%d\n\n", hit_cnt);
 		}
-		
+
 		if (strlen(tmp_str_results) > 0) {
 			// get rid of last dash
 			tmp_str_results[strlen(tmp_str_results)-1] = 0;
@@ -235,7 +235,7 @@ int bayshore_yara_handle_message(int message, YR_RULE* rule, void* data)
 			strncat (yara_meta_results, "detected offsets=", sizeof(yara_meta_results)-strlen(yara_meta_results)-1);
 			strncat (yara_meta_results, tmp_str_results, sizeof(yara_meta_results)-strlen(yara_meta_results)-1);
 		}
-	    
+
 	    /*
 	     * for now let's only display the hit count if there
 	     * is also metadata to display
@@ -305,14 +305,14 @@ int bayshore_yara_callback(
 		}
 
 		return CALLBACK_CONTINUE;
-		
+
 	case CALLBACK_MSG_MODULE_IMPORTED:
 
 		if (show_module_data)
 		{
-			
+
 			object = (YR_OBJECT*) message_data;
-			
+
 			//mutex_lock(&output_mutex);
 
 			yr_object_print_data(object, 0, 1);
@@ -322,7 +322,7 @@ int bayshore_yara_callback(
 		}
 
 		return CALLBACK_CONTINUE;
-		
+
 	}
 	return CALLBACK_ERROR;
 }
@@ -332,7 +332,7 @@ int is_integer(const char *str)
 {
 	if (*str == '-')
 		str++;
-	
+
 	while(*str)
 	{
 		if (!isdigit(*str))
@@ -346,20 +346,20 @@ int is_integer(const char *str)
 int is_float(const char *str)
 {
 	int has_dot = FALSE;
-	
+
 	if (*str == '-')      // skip the minus sign if present
 		str++;
-	
+
 	if (*str == '.')      // float can't start with a dot
 		return FALSE;
-	
+
 	while(*str)
 	{
 		if (*str == '.')
 		{
 			if (has_dot)      // two dots, not a float
 				return FALSE;
-			
+
 			has_dot = TRUE;
 		}
 		else if (!isdigit(*str))
@@ -523,9 +523,9 @@ void cleanup()
 /*
  * had to define a function to use instead of yara's built in
  * macro:
- * 
+ *
  * 		#define exit_with_code(code) { rresult = code; goto _exit; }
- * 		
+ *
  * that macro uses a goto call that assumes it's in the main function.
  * So it kills the rules object. Since we are in an API model we have
  * no main function and I need to return that rules object from the
@@ -534,19 +534,19 @@ void cleanup()
 void exit_with_code_cleanup(int code, YR_COMPILER *compiler, YR_RULES *rules)
 {
 	unload_modules_data();
-	
+
 	if (compiler != NULL)
 		yr_compiler_destroy(compiler);
-	
+
 	if (rules != NULL)
 		yr_rules_destroy(rules);
-	
+
 	yr_finalize();
 }
 
 /*
  * should return a pointer to populated YR_RULES struct,
- * otherwise it should return a pointer to NULL (0) 
+ * otherwise it should return a pointer to NULL (0)
  */
 YR_RULES *bayshore_yara_preprocess_rules (const char *rule_filename)
 {
@@ -644,7 +644,7 @@ YR_RULES *bayshore_yara_preprocess_rules (const char *rule_filename)
 			//exit_with_code(EXIT_FAILURE);
 			exit_with_code_cleanup(EXIT_FAILURE, compiler, rules);
 		}
-	}	
+	}
 	return rules;
 }
 
@@ -665,16 +665,16 @@ int bayshore_yara_wrapper_yrrules_api(
 {
 	int yresult;
 	int errors;
-	
+
 	// clear this for new data
 	*yara_results = 0;
 	*api_yara_results = 0;
 
 	// if there is no content or YR_RULES struct this wont work
 	if (file_content && rules) {
-		
+
 		yresult = yr_initialize();
-		
+
 		yresult = yr_rules_scan_mem(
 				rules,
 				file_content,
@@ -691,7 +691,7 @@ int bayshore_yara_wrapper_yrrules_api(
 
 		yr_finalize();
 		cleanup();
-		
+
 		// we have rule hits from yara
 		if (*yara_results) {
 			snprintf(api_yara_results, MAX_YARA_RES_BUF + 1024, "%s", yara_results);
@@ -712,10 +712,10 @@ int bayshore_yara_wrapper_yrrules_api(
  * this is the original entry point API, it
  * expects a yara ruleset file pointer to be
  * passed in and it will compile those rules
- * into a local YR_RULES struct. This is 
+ * into a local YR_RULES struct. This is
  * sub-optimal because we have to perform
  * that compilation process eveytime this
- * entry point is used, look at 
+ * entry point is used, look at
  * bayshore_yara_wrapper_yrrules_api usage
  * for a faster option
  */
@@ -729,7 +729,7 @@ int bayshore_yara_wrapper_api(
 {
 	int yresult;
 	int errors;
-	FILE* rule_file;	
+	FILE* rule_file;
 	YR_COMPILER* compiler = NULL;
 	YR_RULES* rules = NULL;
 
@@ -739,14 +739,14 @@ int bayshore_yara_wrapper_api(
 
 	// if there is no value in yara_ruleset_filename then yara will not work
 	if (file_content && *yara_ruleset_filename) {
-		
+
 		if (!load_modules_data()) {
 			//exit_with_code(EXIT_FAILURE);
 			exit_with_code_cleanup(EXIT_FAILURE, compiler, rules);
 		}
 
 		yresult = yr_initialize();
-		
+
 		if (yresult != ERROR_SUCCESS)
 		{
 			fprintf(stderr, "error: initialization error (%d)\n", yresult);
@@ -755,10 +755,10 @@ int bayshore_yara_wrapper_api(
 		}
 
 		// Try to load the rules file as a binary file containing
-		// compiled rules first		
+		// compiled rules first
 		yresult = yr_rules_load(yara_ruleset_filename, &rules);
-		
-		
+
+
 		// Accepted result are ERROR_SUCCESS or ERROR_INVALID_FILE
 		// if we are passing the rules in source form, if result is
 		if (yresult != ERROR_SUCCESS &&

--- a/libs/bayshore_yara_wrapper.c
+++ b/libs/bayshore_yara_wrapper.c
@@ -70,11 +70,11 @@ char* identifiers[MAX_ARGS_IDENTIFIER + 1];
 char* ext_vars[MAX_ARGS_EXT_VAR + 1];
 char* modules_data[MAX_ARGS_EXT_VAR + 1];
 
-static int show_strings = TRUE;
-static int show_meta = TRUE;
-static int show_module_data = FALSE;
-static int show_errors = FALSE;
-static int show_warnings = FALSE;
+int show_strings = TRUE;
+int show_meta = TRUE;
+
+int show_errors = FALSE;
+int show_warnings = FALSE;
 
 MODULE_DATA* modules_data_list = NULL;
 
@@ -105,12 +105,6 @@ void print_scanner_error(int error)
 	case ERROR_CORRUPT_FILE:
 		fprintf(stderr, "corrupt compiled rules file.\n");
 		break;
-	case ERROR_EXEC_STACK_OVERFLOW:
-    	fprintf(stderr, "stack overflow while evaluating condition (see --stack-size argument).\n");
-    	break;
-    case ERROR_INVALID_EXTERNAL_VARIABLE_TYPE:
-    	fprintf(stderr, "invalid type for external variable.\n");
-    	break;
 	default:
 		fprintf(stderr, "internal error: %d\n", error);
 		break;
@@ -305,24 +299,6 @@ int bayshore_yara_callback(
 		}
 
 		return CALLBACK_CONTINUE;
-
-	case CALLBACK_MSG_MODULE_IMPORTED:
-
-		if (show_module_data)
-		{
-
-			object = (YR_OBJECT*) message_data;
-
-			//mutex_lock(&output_mutex);
-
-			yr_object_print_data(object, 0, 1);
-			printf("\n");
-
-			//mutex_unlock(&output_mutex);
-		}
-
-		return CALLBACK_CONTINUE;
-
 	}
 	return CALLBACK_ERROR;
 }

--- a/libs/bayshore_yara_wrapper.c
+++ b/libs/bayshore_yara_wrapper.c
@@ -70,11 +70,11 @@ char* identifiers[MAX_ARGS_IDENTIFIER + 1];
 char* ext_vars[MAX_ARGS_EXT_VAR + 1];
 char* modules_data[MAX_ARGS_EXT_VAR + 1];
 
-int show_strings = TRUE;
-int show_meta = TRUE;
-
-int show_errors = FALSE;
-int show_warnings = FALSE;
+static int show_strings = TRUE;
+static int show_meta = TRUE;
+static int show_module_data = FALSE;
+static int show_errors = FALSE;
+static int show_warnings = FALSE;
 
 MODULE_DATA* modules_data_list = NULL;
 

--- a/libs/bayshore_yara_wrapper.c
+++ b/libs/bayshore_yara_wrapper.c
@@ -305,6 +305,25 @@ int bayshore_yara_callback(
 		}
 
 		return CALLBACK_CONTINUE;
+		
+
+	case CALLBACK_MSG_MODULE_IMPORTED:
+
+		if (show_module_data)
+		{
+
+			object = (YR_OBJECT*) message_data;
+
+			//mutex_lock(&output_mutex);
+
+			yr_object_print_data(object, 0, 1);
+			printf("\n");
+
+			//mutex_unlock(&output_mutex);
+		}
+
+		return CALLBACK_CONTINUE;
+
 	}
 	return CALLBACK_ERROR;
 }

--- a/libs/bayshore_yara_wrapper.c
+++ b/libs/bayshore_yara_wrapper.c
@@ -305,7 +305,6 @@ int bayshore_yara_callback(
 		}
 
 		return CALLBACK_CONTINUE;
-		
 
 	case CALLBACK_MSG_MODULE_IMPORTED:
 

--- a/libs/bayshore_yara_wrapper.c
+++ b/libs/bayshore_yara_wrapper.c
@@ -105,6 +105,12 @@ void print_scanner_error(int error)
 	case ERROR_CORRUPT_FILE:
 		fprintf(stderr, "corrupt compiled rules file.\n");
 		break;
+	case ERROR_EXEC_STACK_OVERFLOW:
+    		fprintf(stderr, "stack overflow while evaluating condition (see --stack-size argument).\n");
+    		break;
+    	case ERROR_INVALID_EXTERNAL_VARIABLE_TYPE:
+    		fprintf(stderr, "invalid type for external variable.\n");
+    		break;
 	default:
 		fprintf(stderr, "internal error: %d\n", error);
 		break;

--- a/libs/bayshore_yara_wrapper.h
+++ b/libs/bayshore_yara_wrapper.h
@@ -3,7 +3,7 @@
  * YEXTEND: Help for YARA users.
  * This file is part of yextend.
  *
- * Copyright (c) 2014-2017, Bayshore Networks, Inc.
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that

--- a/libs/bayshore_yara_wrapper.h
+++ b/libs/bayshore_yara_wrapper.h
@@ -5,19 +5,19 @@
  *
  * Copyright (c) 2014-2017, Bayshore Networks, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
  * following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
  * following disclaimer in the documentation and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
  * products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
@@ -38,13 +38,13 @@
 /*
  * 06/10/2016 - Dre
  * increased this buffer to 1 MB because some of the file type
- * detection stuff returns a lot of data and I need to see it 
+ * detection stuff returns a lot of data and I need to see it
  * all in order to find the right type
  */
 #define MAX_YARA_RES_BUF 1048576
-#define YEXTEND_VERSION 1.6
+#define YEXTEND_VERSION 1.7
 
-/* 
+/*
  * When calling bayshore_yara_wrapper_api, the next-to-last parameter is a
  * pointer to a caller-supplied char buffer. The caller is required to ensure
  * that this buffer is at least MAX_YARA_RES_BUF bytes long.
@@ -63,4 +63,3 @@ int bayshore_yara_wrapper_yrrules_api(uint8_t*, size_t, YR_RULES *, char *, size
 
 
 #endif // __bayshoreyarawrapper__H_
-

--- a/libs/pdf.cpp
+++ b/libs/pdf.cpp
@@ -1,8 +1,31 @@
-/*
+/*****************************************************************************
  *
- *  Created on: Nov 29, 2017
- *      Author: rodrigo
- */
+ * YEXTEND: Help for YARA users.
+ * This file is part of yextend.
+ *
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
 
 /* Include order
 Own .h.
@@ -278,4 +301,3 @@ size_t Pdf::Size(){
 } // !extern "C"
 
 } // !namespace pdfparser
-

--- a/libs/pdf.cpp
+++ b/libs/pdf.cpp
@@ -1,33 +1,18 @@
-/*****************************************************************************
+/*
  *
- * YEXTEND: Help for YARA users.
- * This file is part of yextend.
- *
- * Copyright (c) 2014-2018, Bayshore Networks, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- * the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- * following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
+ *  Created on: Nov 29, 2017
+ *      Author: rodrigo
+ */
 
+/* Include order
+Own .h.
+C.
+C++.
+Other libraries' .h files.
+Your project's .h files.
+*/
 #include "pdf.h"
+
 #include <cstring>
 
 #include <algorithm>
@@ -47,146 +32,250 @@
 
 namespace pdfparser {
 
-    extern "C" {
+extern "C" {
 
-        Pdf::Pdf(const uint8_t* buffer, size_t size) {
-	        start_pdf = buffer;
-	        length_pdf = size;
+Pdf::Pdf(const uint8_t* buffer, size_t size){
+	start_pdf = buffer;
+	length_pdf = size;
 
-	        auto current_obj_pointer = buffer;
-	        auto current_obj_size = size;
+	auto current_obj_pointer = buffer;
+	auto current_obj_size = size;
 
-	        while (current_obj_size > 0 && current_obj_size != std::string::npos) {
-		        PdfObject pdf_object{current_obj_pointer, current_obj_size};
+	while (current_obj_size > 0 && current_obj_size != std::string::npos){
+		PdfObject pdf_object{current_obj_pointer, current_obj_size};
 
-		        auto id = pdf_object.GetId();
-		        objects.emplace(id, pdf_object);
+		auto id = pdf_object.GetId();
+		//objects.insert(make_pair(id, pdf_object));
 
-		        BuildObjReference(pdf_object.GetDictionary()); //	Build objects reference library
+		if (id != "") { // for xref and so it is not recognized as pdf object
+			objects.emplace(id, pdf_object);
+			BuildObjReference(pdf_object.GetDictionary()); //	Build objects reference library
+		}
 
-		        current_obj_size = current_obj_size - (pdf_object.GetObjectEnd() - current_obj_pointer);
-		        current_obj_pointer = pdf_object.GetObjectEnd();
-	        }
-        }
+		current_obj_size = current_obj_size - (pdf_object.GetObjectEnd() - current_obj_pointer);
+		current_obj_pointer = pdf_object.GetObjectEnd();
+	}
+}
 
-        Pdf::~Pdf() {
-	        for (auto obj: objects) {
-		        Dictionary* dictionary = obj.second.GetDictionary();
-		        if (dictionary->dictionaries.size() > 0)
-			        DeleteDictionary(dictionary);
-	        }
-        }
 
-        void Pdf::DeleteDictionary(Dictionary* dictionary) {
-	        for (auto x: dictionary->dictionaries) {
-		        DeleteDictionary(x.second);
-		        delete x.second;
-	        }
-        }
+Pdf::~Pdf() {
+	for (auto obj: objects){
+		Dictionary* dictionary = obj.second.GetDictionary();
+		if (dictionary->dictionaries.size() > 0)
+			DeleteDictionary(dictionary);
+	}
+}
 
-        void Pdf::GetXref() {
-	        //  It can point to a plain xref object or to a streamed xref object
-	        xref_offset = FindStringInBufferReverse(start_pdf, "startxref", length_pdf); // TODO Verify
 
-	        if(memcmp (start_pdf+xref_offset, "xref", 4)){
-		        ;} //TODO
-        }
+void Pdf::DeleteDictionary(Dictionary* dictionary){
+	for (auto x: dictionary->dictionaries) {
+		DeleteDictionary(x.second);
+		delete x.second;
+	}
+}
 
-        void Pdf::BuildObjReference(Dictionary* dictionary) {
-	        const std::string kObjRefRegEx = "^[0-9]+[[:space:]]+[0-9]+"; // for indirect object reference '0 5 R'
-	        const std::regex obj_ref_regex {kObjRefRegEx};
-	        std::smatch sm;
 
-	        // Values
-	        for (auto x: dictionary->values) {
-		        std::regex_search (x.second, sm, obj_ref_regex);
-		        if (sm.size() > 0) {
-			        obj_ref[x.second] = x.first;
-		        }
-	        }
-	        // Dictionaries
-	        for (auto x: dictionary->dictionaries) {
-		        BuildObjReference(x.second);
+void Pdf::GetXref(){
+	//  It can point to a plain xref object or to a streamed xref object
+	xref_offset = FindStringInBufferReverse(start_pdf, "startxref", length_pdf); // TODO Verify
 
-	        }
-        }
+	if(memcmp (start_pdf+xref_offset, "xref", 4)){
+		;} //TODO
+}
 
-        std::vector<uint8_t> Pdf::ExtractText() {
-	        auto accepted = kFilterDictionary;
-	        auto rejected_attributes = kNonTextAttributes;
-	        auto rejected_dictionary = kNonTextDictionary;
 
-	        std::vector<uint8_t> text_buffer{};
-	        auto whole_text = text_buffer;
+void Pdf::BuildObjReference(Dictionary* dictionary){
+	const std::regex obj_ref_regex {Pdf::kObjectReferenceRegEx};
+	std::smatch sm;
 
-	        for (auto map_obj: objects) {
-		        auto id = map_obj.first;
-		        auto obj = map_obj.second;
-	            auto flag = obj_ref[id];
+	// Values
+	for (auto x: dictionary->values) {
+		std::regex_search (x.second, sm, obj_ref_regex);
+		if (sm.size() > 0) {
+			obj_ref[x.second] = x.first;
+		}
+	}
+	// Dictionaries
+	for (auto x: dictionary->dictionaries) {
+		BuildObjReference(x.second);
 
-	            bool in_rejected_dict{false};
-	            for (auto key: obj.GetDictionary()->values) {
-	            	if (rejected_dictionary.end() != std::find(rejected_dictionary.begin(),
-	            			rejected_dictionary.end(), key.first)) {
-	            		in_rejected_dict = true;
-	            		break;
-	            	}
-	            }
+	}
+}
 
-		        if (obj.HasStream() && !in_rejected_dict &&
-			        ((accepted.end() != std::find(accepted.begin(), accepted.end(), flag)) || //It is in accepted or
-			        (rejected_attributes.end() == std::find(rejected_attributes.begin(), rejected_attributes.end(), flag)))) { //it is not in rejected then process
+void Pdf::BuildFonts(){
 
-			        if (obj.ExtractStream((obj.GetDictionary())->values["Filter"])){
-				        obj.TextParser();
-        				text_buffer = obj.GetParsedText();
-				        whole_text.insert(whole_text.end(), text_buffer.begin(), text_buffer.end());
-			        }
-		        }
-	        }
+	const std::regex obj_ref_regex {Pdf::kObjectReferenceRegEx};
+	std::smatch sm;
 
-	        return whole_text;
-        }
+	//bool font_found{false};
 
-        std::vector<std::vector<uint8_t>> Pdf::ExtractFile() { //TODO
-	        auto accepted = kFileFlag;
-	        auto rejected_attributes = kNonFileAttributes;
-	        auto rejected_dictionary = kNonFileDictionary;
+	// Objects are sweep sequentially because a font definition
+	// can be a indirect reference or embedded data as a dictionary as a value of /Font
+	for (auto object_map: objects) {
+		auto object = object_map.second;
+		auto dictionary = object.GetDictionary();
 
-	        std::vector<std::vector<uint8_t>> all_files {};
+#ifdef DEBUG
+		if (object.GetId() == "4 0") {
+			std::cout << "DEBUG\n";
+		}
+		std::cout << "Pdf::BuildFonts Obj id: " << object.GetId() << '\n';
+#endif
 
-	        for (auto map_obj: objects) {
-		        auto id = map_obj.first;
-		        auto obj = map_obj.second;
-	            auto flag = obj_ref[id];
+		// Detect /Font key in dictionary
+		// The result can be a indirect reference "65 0" or a dictionary in string format "<</F1 5 0>
+		auto font_definition = object.ExtractFontDefinition(dictionary);
 
-	            bool in_rejected_dict{false};
-	            for (auto key: obj.GetDictionary()->values) { // Todo verify object 66
-	            	if (rejected_dictionary.end() != std::find(rejected_dictionary.begin(),
-	            			rejected_dictionary.end(), key.second)) {
-	            		in_rejected_dict = true;
-	            		break;
-	            	}
-	            }
+		// Font found
+		if (font_definition.size() > 0) {
+			Dictionary* font_dictionary;
+			bool new_dictionary{false};
 
-		        if (obj.HasStream() && !in_rejected_dict &&
-			        ((accepted.end() != std::find(accepted.begin(), accepted.end(), flag)) || //It is in accepted or
-			        (rejected_attributes.end() == std::find(rejected_attributes.begin(), rejected_attributes.end(), flag)))) { //it is not in rejected then process
+			// font_definition is an indirect reference
+			if (font_definition.substr(0, kDictionaryBegin.size()) != kDictionaryBegin) {
+				font_dictionary = objects.find(font_definition)->second.GetDictionary();
+			}
 
-			        if (obj.ExtractStream((obj.GetDictionary())->values["Filter"])) {
-				        auto temp = obj.GetDecodedStream();
-				        all_files.push_back(obj.GetDecodedStream());
-			        }
-		        }
-	        }
+			// It is an embedded dictionary TESTME
+			else {
+				new_dictionary = true;
+				font_dictionary = new Dictionary{};
+				auto font_begin = reinterpret_cast<const uint8_t*>(&font_definition[0]);
+				object.UnfoldDictionary(font_dictionary, font_begin, font_begin+font_definition.size());
+			}
 
-	        return all_files;
-        }
+			// Creates fonts
+			for (auto font_it = font_dictionary->values.begin(); font_it != font_dictionary->values.end(); ++font_it){
 
-        size_t Pdf::Size(){
-	        return objects.size();
+				auto font_id = font_it->first;
+				Font font{font_id};
+
+				auto font_object = objects[font_it->second];
+
+				auto to_unicode_reference = font_object.GetDictionary()->values[kToUnicode];
+
+				// It has /ToUnicode
+				if (to_unicode_reference != "") {
+					auto unicode = objects[to_unicode_reference];
+
+					// TODO multiple filters in cascade
+					auto filter = unicode.GetDictionary()->values[kFilterTagBegin];
+
+					unicode.ExtractStream(filter);
+					auto bytes_cmap = unicode.GetDecodedStream();
+					std::string cmap(bytes_cmap.begin(), bytes_cmap.end());
+					font.BuildUnicodeMap(cmap);
+				}
+
+				fonts[font_id] = font;
+			}
+
+			// If a new dictionary for font reference '/F1 5 0 R' was needed, destroy it
+			if (new_dictionary) {
+				delete (font_dictionary);
+			}
+		}
+	}
+}
+
+
+std::vector<uint8_t> Pdf::ExtractText(TextEncoding encoding){
+	auto accepted = kFilterDictionary;
+	auto rejected_attributes = kNonTextAttributes;
+	auto rejected_dictionary = kNonTextDictionary;
+
+	// BuildFonts is executed once Pdf::ExtractText is called (has no sense to execute it in advance
+	// and when all objects are in memory to be sure of having all objects referred indirectly
+	Pdf::BuildFonts();
+
+	std::vector<uint8_t> text_buffer{};
+	auto whole_text = text_buffer;
+
+	for (auto map_obj: objects) {
+		auto id = map_obj.first;
+		auto obj = map_obj.second;
+	    auto flag = obj_ref[id];
+
+	    bool in_rejected_dict{false};
+	    for (auto key: obj.GetDictionary()->values) {
+	    	if (rejected_dictionary.end() != std::find(rejected_dictionary.begin(),
+	    			rejected_dictionary.end(), key.first)) {
+	    		in_rejected_dict = true;
+	    		break;
+	    	}
 	    }
 
-    } // !extern "C"
+		if (obj.HasStream() && !in_rejected_dict &&
+			((accepted.end() != std::find(accepted.begin(), accepted.end(), flag)) || //It is in accepted or
+			(rejected_attributes.end() == std::find(rejected_attributes.begin(), rejected_attributes.end(), flag)))) { //it is not in rejected then process
+
+			if (obj.ExtractStream((obj.GetDictionary())->values[kFilterTagBegin])){
+
+				obj.ParseText(fonts);
+				text_buffer = obj.GetParsedPlainText(encoding);
+				whole_text.insert(whole_text.end(), text_buffer.begin(), text_buffer.end());
+			}
+
+		}
+	}
+	return whole_text;
+}
+
+
+std::vector<std::vector<uint8_t>> Pdf::ExtractFile(){ //TODO
+	auto accepted_keys = kFileAcceptedKeys;
+	auto rejected_attributes = kNonFileAttributes;
+	auto rejected_dictionary = kNonFileDictionary;
+
+	std::vector<uint8_t> file_buffer{};
+	std::vector<std::vector<uint8_t>> all_files {};
+
+	for (auto map_obj: objects) {
+
+		auto id = map_obj.first;
+		auto obj = map_obj.second;
+	    auto flag = obj_ref[id];
+
+	    bool is_rejected_dict{false};
+	    bool is_accepted_keys{false};
+	    for (auto key: obj.GetDictionary()->values) { // Todo verify object 66
+	    	if (rejected_dictionary.end() != std::find(rejected_dictionary.begin(),
+	    			rejected_dictionary.end(), key.second)) {
+	    		is_rejected_dict = true;
+	    		break;
+	    	}
+	    	if (accepted_keys.end() != std::find(accepted_keys.begin(), accepted_keys.end(), key.first)) {
+	    		is_accepted_keys = true;
+	    		break;
+	    	}
+	    }
+
+	    bool is_rejected_attributes =
+	    		rejected_attributes.end() != std::find(rejected_attributes.begin(), rejected_attributes.end(), flag);
+
+	    //  Has stream AND not in rejected dictionary AND not in rejected attribute AND
+	    // (accepted attribures OR flag is not empty)
+	    // not in rejected attributes)
+	    if (obj.HasStream() && !is_rejected_dict && !is_rejected_attributes &&
+	    		(is_accepted_keys || (flag != ""))) {
+
+	    	if (obj.ExtractStream((obj.GetDictionary())->values[kFilterTagBegin])) {
+				auto temp = obj.GetDecodedStream();
+				all_files.push_back(obj.GetDecodedStream());
+			}
+		}
+	}
+
+	return all_files;
+}
+
+
+size_t Pdf::Size(){
+	return objects.size();
+	}
+
+
+} // !extern "C"
 
 } // !namespace pdfparser
+

--- a/libs/pdf.cpp
+++ b/libs/pdf.cpp
@@ -1,0 +1,191 @@
+/*****************************************************************************
+ *
+ * YEXTEND: Help for YARA users.
+ * This file is part of yextend.
+ *
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+
+#include "pdf.h"
+#include <cstring>
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <istream>
+#include <iostream> //debugging
+#include <list>
+#include <map>
+#include <regex>
+#include <string>
+#include <sstream>
+#include <vector>
+
+#include "pdf_object.h"
+#include "pdf_parser_helper.h"
+
+namespace pdfparser {
+
+    extern "C" {
+
+        Pdf::Pdf(const uint8_t* buffer, size_t size) {
+	        start_pdf = buffer;
+	        length_pdf = size;
+
+	        auto current_obj_pointer = buffer;
+	        auto current_obj_size = size;
+
+	        while (current_obj_size > 0 && current_obj_size != std::string::npos) {
+		        PdfObject pdf_object{current_obj_pointer, current_obj_size};
+
+		        auto id = pdf_object.GetId();
+		        objects.emplace(id, pdf_object);
+
+		        BuildObjReference(pdf_object.GetDictionary()); //	Build objects reference library
+
+		        current_obj_size = current_obj_size - (pdf_object.GetObjectEnd() - current_obj_pointer);
+		        current_obj_pointer = pdf_object.GetObjectEnd();
+	        }
+        }
+
+        Pdf::~Pdf() {
+	        for (auto obj: objects) {
+		        Dictionary* dictionary = obj.second.GetDictionary();
+		        if (dictionary->dictionaries.size() > 0)
+			        DeleteDictionary(dictionary);
+	        }
+        }
+
+        void Pdf::DeleteDictionary(Dictionary* dictionary) {
+	        for (auto x: dictionary->dictionaries) {
+		        DeleteDictionary(x.second);
+		        delete x.second;
+	        }
+        }
+
+        void Pdf::GetXref() {
+	        //  It can point to a plain xref object or to a streamed xref object
+	        xref_offset = FindStringInBufferReverse(start_pdf, "startxref", length_pdf); // TODO Verify
+
+	        if(memcmp (start_pdf+xref_offset, "xref", 4)){
+		        ;} //TODO
+        }
+
+        void Pdf::BuildObjReference(Dictionary* dictionary) {
+	        const std::string kObjRefRegEx = "^[0-9]+[[:space:]]+[0-9]+"; // for indirect object reference '0 5 R'
+	        const std::regex obj_ref_regex {kObjRefRegEx};
+	        std::smatch sm;
+
+	        // Values
+	        for (auto x: dictionary->values) {
+		        std::regex_search (x.second, sm, obj_ref_regex);
+		        if (sm.size() > 0) {
+			        obj_ref[x.second] = x.first;
+		        }
+	        }
+	        // Dictionaries
+	        for (auto x: dictionary->dictionaries) {
+		        BuildObjReference(x.second);
+
+	        }
+        }
+
+        std::vector<uint8_t> Pdf::ExtractText() {
+	        auto accepted = kFilterDictionary;
+	        auto rejected_attributes = kNonTextAttributes;
+	        auto rejected_dictionary = kNonTextDictionary;
+
+	        std::vector<uint8_t> text_buffer{};
+	        auto whole_text = text_buffer;
+
+	        for (auto map_obj: objects) {
+		        auto id = map_obj.first;
+		        auto obj = map_obj.second;
+	            auto flag = obj_ref[id];
+
+	            bool in_rejected_dict{false};
+	            for (auto key: obj.GetDictionary()->values) {
+	            	if (rejected_dictionary.end() != std::find(rejected_dictionary.begin(),
+	            			rejected_dictionary.end(), key.first)) {
+	            		in_rejected_dict = true;
+	            		break;
+	            	}
+	            }
+
+		        if (obj.HasStream() && !in_rejected_dict &&
+			        ((accepted.end() != std::find(accepted.begin(), accepted.end(), flag)) || //It is in accepted or
+			        (rejected_attributes.end() == std::find(rejected_attributes.begin(), rejected_attributes.end(), flag)))) { //it is not in rejected then process
+
+			        if (obj.ExtractStream((obj.GetDictionary())->values["Filter"])){
+				        obj.TextParser();
+				        whole_text.insert(whole_text.end(), text_buffer.begin(), text_buffer.end());
+			        }
+		        }
+	        }
+
+	        return whole_text;
+        }
+
+        std::vector<std::vector<uint8_t>> Pdf::ExtractFile() { //TODO
+	        auto accepted = kFileFlag;
+	        auto rejected_attributes = kNonFileAttributes;
+	        auto rejected_dictionary = kNonFileDictionary;
+
+	        std::vector<std::vector<uint8_t>> all_files {};
+
+	        for (auto map_obj: objects) {
+		        auto id = map_obj.first;
+		        auto obj = map_obj.second;
+	            auto flag = obj_ref[id];
+
+	            bool in_rejected_dict{false};
+	            for (auto key: obj.GetDictionary()->values) { // Todo verify object 66
+	            	if (rejected_dictionary.end() != std::find(rejected_dictionary.begin(),
+	            			rejected_dictionary.end(), key.second)) {
+	            		in_rejected_dict = true;
+	            		break;
+	            	}
+	            }
+
+		        if (obj.HasStream() && !in_rejected_dict &&
+			        ((accepted.end() != std::find(accepted.begin(), accepted.end(), flag)) || //It is in accepted or
+			        (rejected_attributes.end() == std::find(rejected_attributes.begin(), rejected_attributes.end(), flag)))) { //it is not in rejected then process
+
+			        if (obj.ExtractStream((obj.GetDictionary())->values["Filter"])) {
+				        auto temp = obj.GetDecodedStream();
+				        all_files.push_back(obj.GetDecodedStream());
+			        }
+		        }
+	        }
+
+	        return all_files;
+        }
+
+        size_t Pdf::Size(){
+	        return objects.size();
+	    }
+
+    } // !extern "C"
+
+} // !namespace pdfparser

--- a/libs/pdf.cpp
+++ b/libs/pdf.cpp
@@ -97,7 +97,7 @@ void Pdf::DeleteDictionary(Dictionary* dictionary){
 	}
 }
 
-
+/*
 void Pdf::GetXref(){
 	//  It can point to a plain xref object or to a streamed xref object
 	xref_offset = FindStringInBufferReverse(start_pdf, "startxref", length_pdf); // TODO Verify
@@ -105,7 +105,7 @@ void Pdf::GetXref(){
 	if(memcmp (start_pdf+xref_offset, "xref", 4)){
 		;} //TODO
 }
-
+*/
 
 void Pdf::BuildObjReference(Dictionary* dictionary){
 	const std::regex obj_ref_regex {Pdf::kObjectReferenceRegEx};
@@ -126,11 +126,6 @@ void Pdf::BuildObjReference(Dictionary* dictionary){
 }
 
 void Pdf::BuildFonts(){
-
-	const std::regex obj_ref_regex {Pdf::kObjectReferenceRegEx};
-	std::smatch sm;
-
-	//bool font_found{false};
 
 	// Objects are sweep sequentially because a font definition
 	// can be a indirect reference or embedded data as a dictionary as a value of /Font
@@ -205,7 +200,7 @@ void Pdf::BuildFonts(){
 std::vector<uint8_t> Pdf::ExtractText(TextEncoding encoding){
 	auto accepted = kFilterDictionary;
 	auto rejected_attributes = kNonTextAttributes;
-	auto rejected_dictionary = kNonTextDictionary;
+	auto rejected_dictionary = kNonTextDictionaryKeys;
 
 	// BuildFonts is executed once Pdf::ExtractText is called (has no sense to execute it in advance
 	// and when all objects are in memory to be sure of having all objects referred indirectly
@@ -221,8 +216,8 @@ std::vector<uint8_t> Pdf::ExtractText(TextEncoding encoding){
 
 	    bool in_rejected_dict{false};
 	    for (auto key: obj.GetDictionary()->values) {
-	    	if (rejected_dictionary.end() != std::find(rejected_dictionary.begin(),
-	    			rejected_dictionary.end(), key.first)) {
+	    	if ((rejected_dictionary.end() != std::find(rejected_dictionary.begin(), rejected_dictionary.end(), key.first)) ||
+	    			(rejected_dictionary.end() != std::find(rejected_dictionary.begin(), rejected_dictionary.end(), key.second))){
 	    		in_rejected_dict = true;
 	    		break;
 	    	}
@@ -250,7 +245,6 @@ std::vector<std::vector<uint8_t>> Pdf::ExtractFile(){ //TODO
 	auto rejected_attributes = kNonFileAttributes;
 	auto rejected_dictionary = kNonFileDictionary;
 
-	std::vector<uint8_t> file_buffer{};
 	std::vector<std::vector<uint8_t>> all_files {};
 
 	for (auto map_obj: objects) {
@@ -301,3 +295,4 @@ size_t Pdf::Size(){
 } // !extern "C"
 
 } // !namespace pdfparser
+

--- a/libs/pdf.cpp
+++ b/libs/pdf.cpp
@@ -139,6 +139,7 @@ namespace pdfparser {
 
 			        if (obj.ExtractStream((obj.GetDictionary())->values["Filter"])){
 				        obj.TextParser();
+        				text_buffer = obj.GetParsedText();
 				        whole_text.insert(whole_text.end(), text_buffer.begin(), text_buffer.end());
 			        }
 		        }

--- a/libs/pdf.h
+++ b/libs/pdf.h
@@ -27,9 +27,17 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
 
+
 #ifndef PDF_H_
 #define PDF_H_
 
+/* Include order
+Own .h.
+C.
+C++.
+Other libraries' .h files.
+Your project's .h files.
+*/
 #include <stdint.h>
 
 #include <cstddef>
@@ -60,7 +68,7 @@ class Pdf {
 	std::map<std::string, std::string> 			obj_ref{}; // Map of objects that are the indirect reference for certain dictionary key (
 	std::map<std::string, pdfparser::Font>		fonts{}; // Key: Font ID. Value: Font
 
-	void GetXref();
+	//void GetXref();
 	void BuildObjReference(Dictionary* dictionary);
 
 	/**

--- a/libs/pdf.h
+++ b/libs/pdf.h
@@ -27,24 +27,48 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
 
-#ifndef PDF_PARSER_H_
-#define PDF_PARSER_H_
+#ifndef PDF_H_
+#define PDF_H_
+
+#include <stdint.h>
 
 #include <cstddef>
-#include <stdint.h>
+#include <string>
+#include <map>
 #include <vector>
 
-#include "pdf.h"
+#include "pdf_object.h"
 
 namespace pdfparser {
 
     extern "C" {
 
-        std::vector<uint8_t> PdfToText (const uint8_t* pdf_start, size_t pdf_size);
-        std::vector<std::vector<uint8_t>> PdfDetach (uint8_t* pdf_start, size_t pdf_size);
+        class Pdf {
+	        size_t xref_offset{0}; // Offset to start of xref from start_pdf
+	        std::vector<size_t> xref{}; // Offset of each 'obj' in pdf
+
+	        const uint8_t* start_pdf{nullptr};
+	        size_t length_pdf{0};
+
+	        std::map<std::string, PdfObject> objects{};
+
+	        std::map<std::string, std::string> obj_ref;
+
+	        void BuildObjReference(Dictionary* dictionary);
+	        void DeleteDictionary(Dictionary* dictionary);
+            void GetXref();
+
+        public:
+	        Pdf(const uint8_t* buffer, size_t size);
+	        ~Pdf();
+
+	        size_t Size();
+	        std::vector<uint8_t> ExtractText();
+	        std::vector<std::vector<uint8_t>> ExtractFile();
+        };
 
     } // !extern "C"
 
 } // !namespace pdfparser
 
-#endif /* PDF_PARSER_H_ */
+#endif /* PDF_H_ */

--- a/libs/pdf.h
+++ b/libs/pdf.h
@@ -1,31 +1,8 @@
-/*****************************************************************************
+/*
  *
- * YEXTEND: Help for YARA users.
- * This file is part of yextend.
- *
- * Copyright (c) 2014-2018, Bayshore Networks, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- * the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- * following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
+ *  Created on: Nov 29, 2017
+ *      Author: rodrigo
+ */
 
 #ifndef PDF_H_
 #define PDF_H_
@@ -37,38 +14,55 @@
 #include <map>
 #include <vector>
 
+#include "pdf_font.h"
 #include "pdf_object.h"
+#include "pdf_text_encoding.h"
 
 namespace pdfparser {
 
-    extern "C" {
+extern "C" {
 
-        class Pdf {
-	        size_t xref_offset{0}; // Offset to start of xref from start_pdf
-	        std::vector<size_t> xref{}; // Offset of each 'obj' in pdf
 
-	        const uint8_t* start_pdf{nullptr};
-	        size_t length_pdf{0};
 
-	        std::map<std::string, PdfObject> objects{};
+class Pdf {
+	const std::string kObjectReferenceRegEx = "^[0-9]+[[:space:]]+[0-9]+"; // for indirect object reference '0 5 R'
 
-	        std::map<std::string, std::string> obj_ref;
+	size_t xref_offset{0}; // Offset to start of xref from start_pdf
+	std::vector<size_t> xref{}; // Offset of each 'obj' in pdf
 
-	        void BuildObjReference(Dictionary* dictionary);
-	        void DeleteDictionary(Dictionary* dictionary);
-            void GetXref();
+	const uint8_t* start_pdf{nullptr};
+	size_t length_pdf{0};
 
-        public:
-	        Pdf(const uint8_t* buffer, size_t size);
-	        ~Pdf();
+	std::unordered_map<std::string, PdfObject> 	objects{};
+	std::map<std::string, std::string> 			obj_ref{}; // Map of objects that are the indirect reference for certain dictionary key (
+	std::map<std::string, pdfparser::Font>		fonts{}; // Key: Font ID. Value: Font
 
-	        size_t Size();
-	        std::vector<uint8_t> ExtractText();
-	        std::vector<std::vector<uint8_t>> ExtractFile();
-        };
+	void GetXref();
+	void BuildObjReference(Dictionary* dictionary);
 
-    } // !extern "C"
+	/**
+	 * @brief Build the needed Font objects and fill the class attribute fonts.
+	 *
+	 */
+	void BuildFonts(void);
+	void DeleteDictionary(Dictionary* dictionary);
+
+public:
+	Pdf(const uint8_t* buffer, size_t size);
+	~Pdf();
+
+	size_t Size();
+	std::vector<uint8_t> ExtractText(TextEncoding encoding);
+	std::vector<std::vector<uint8_t>> ExtractFile();
+};
+
+
+
+
+
+} // !extern "C"
 
 } // !namespace pdfparser
+
 
 #endif /* PDF_H_ */

--- a/libs/pdf.h
+++ b/libs/pdf.h
@@ -1,8 +1,31 @@
-/*
+/*****************************************************************************
  *
- *  Created on: Nov 29, 2017
- *      Author: rodrigo
- */
+ * YEXTEND: Help for YARA users.
+ * This file is part of yextend.
+ *
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
 
 #ifndef PDF_H_
 #define PDF_H_

--- a/libs/pdf_font.cpp
+++ b/libs/pdf_font.cpp
@@ -1,8 +1,31 @@
-/*
+/*****************************************************************************
  *
- *  Created on: Feb 16, 2018
- *      Author: rodrigo
- */
+ * YEXTEND: Help for YARA users.
+ * This file is part of yextend.
+ *
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
 
 /* Include order
 Own .h.

--- a/libs/pdf_font.cpp
+++ b/libs/pdf_font.cpp
@@ -34,7 +34,6 @@ C++.
 Other libraries' .h files.
 Your project's .h files.
 */
-//#include <stdint.h>
 
 #include "pdf_font.h"
 
@@ -49,9 +48,7 @@ namespace pdfparser {
 extern "C" {
 Font::Font (){};
 
-Font::Font (std::string id) {
-	this->id = id;
-}
+Font::Font (std::string id) : id(id) {}
 
 
 void Font::BuildUnicodeMap(std::string raw_cidfont) {

--- a/libs/pdf_font.cpp
+++ b/libs/pdf_font.cpp
@@ -1,0 +1,104 @@
+/*
+ *
+ *  Created on: Feb 16, 2018
+ *      Author: rodrigo
+ */
+
+/* Include order
+Own .h.
+C.
+C++.
+Other libraries' .h files.
+Your project's .h files.
+*/
+//#include <stdint.h>
+
+#include "pdf_font.h"
+
+#include <iostream>
+#include <iterator>
+#include <regex>
+#include <string>
+
+
+namespace pdfparser {
+
+extern "C" {
+Font::Font (){};
+
+Font::Font (std::string id) {
+	this->id = id;
+}
+
+
+void Font::BuildUnicodeMap(std::string raw_cidfont) {
+	const std::regex cid_unicode_re {R"(^<([[:xdigit:]]{2})>\s*<([[:xdigit:]]+)>\s*([\s\S]*))"};
+	const std::string cid_ordering = kCmapOrdering+R"(\s*\(([[:w:]]+)\))";
+	const std::regex cid_ordering_re {cid_ordering};// TODO regex for ordering
+	std::smatch sm;
+
+	// Looks up /Ordering to get endianess
+	auto begin = raw_cidfont.find(kCmapBegin) + kCmapBegin.size();
+	begin = raw_cidfont.find(kCmapOrdering, begin);
+	auto last_part = raw_cidfont.substr(begin, std::string::npos);
+
+	std::regex_search (last_part, sm, cid_ordering_re);
+	encoding = sm.str(1);
+
+	// Looks up encoded chars
+	begin = last_part.find(kBeginBFChar, begin) + kBeginBFChar.size();
+	begin = last_part.find(kBeginHex, begin);
+
+	auto end = last_part.find(kEndBFChar, begin);
+	last_part = last_part.substr(begin, end-begin);
+
+	std::regex_search (last_part, sm, cid_unicode_re);
+	auto cmap_elem = sm.size();
+
+	while (cmap_elem >= 3) {
+
+		#ifdef DEBUG
+		//std::cout << "Elements of sm: "<< cmap_elem << std::endl;
+		std::cout << "Element 1(cid): " << sm.str(1) << std::endl;
+		std::cout << "Element 2(unicode): " << sm.str(2) << std::endl;
+		//std::cout << "Last elem(rest): " << sm.str(cmap_elem-1) << std::endl;
+		#endif
+
+		std::string cid = sm.str(1); // It is the cid of cid-value pair
+		std::string unicode_str = sm.str(2);
+		last_part = sm.str(cmap_elem-1);
+
+		// Orders bytes according little endian or big endian
+		/*
+		for (auto it = unicode_str.begin(); it != unicode_str.end(); it+=4) {
+			Utf16ToByte input;
+			std::string utf16(it, it+4); // 4 hexa numbers
+			input.utf16 = stoi(utf16, nullptr, 16);
+			unicode_map[cid].insert(unicode_map[cid].end(), input.byte, input.byte+2);
+		}
+		*/
+
+		// Stores encoding as is
+		for (auto it = unicode_str.begin(); it != unicode_str.end(); it+=2) {
+			std::string utf16(it, it+2); // 2 hexa numbers
+			unicode_map[cid].push_back(stoi(utf16, nullptr, 16));
+		}
+
+		std::regex_search (last_part, sm, cid_unicode_re);
+		cmap_elem = sm.size();
+	}
+}
+
+
+UNICODE_MAP Font::GetUnicodeMap() {
+	return unicode_map;
+}
+
+
+const char* Font::GetFontEndianess() {
+	return kOrdering.at(encoding).c_str();
+}
+
+} // !extern "C"
+
+} // !namespace pdfparser

--- a/libs/pdf_font.h
+++ b/libs/pdf_font.h
@@ -1,0 +1,73 @@
+/*
+ *
+ *  Created on: Feb 16, 2018
+ *      Author: rodrigo
+ */
+
+#ifndef FONT_H_
+#define FONT_H_
+
+//#define DEBUG
+
+/* Include order
+Own .h.
+C.
+C++.
+Other libraries' .h files.
+Your project's .h files.
+*/
+
+#include <cstddef>
+#include <string>
+#include <map>
+#include <vector>
+
+namespace pdfparser {
+
+extern "C" {
+
+using UNICODE_MAP=std::map<std::string, std::vector<uint8_t>>;
+//typedef std::map<std::string, std::string> UNICODE_MAP;
+
+const std::string kCmapBegin			{"begincmap"};
+const std::string kCmapOrdering			{"/Ordering"};
+const std::string kCodeSpaceRangeBegin 	{"begincodespacerange"};
+const std::string kBeginBFChar			{"beginbfchar"};
+const std::string kEndBFChar			{"endbfchar"};
+const std::string kBeginHex				{"<"};
+
+
+const std::map<std::string, const std::string> kOrdering = {
+		{"None", "UTF-8"},
+		{"UCS", "UTF-16BE"}
+};
+
+
+class Font {
+	union Utf16ToByte {
+		uint8_t byte[2];
+		char16_t utf16;
+	};
+	std::string id{};
+	std::string base_font{"None"};
+	std::string encoding {"None"};
+	UNICODE_MAP unicode_map{}; // Key: cid, value: Unicode
+
+public:
+	Font();
+	Font(std::string id);
+
+	/**
+	 * @brief					Parses the unicode map and fills up unicode_map
+	 * @param raw_definition	string with raw CIDFont
+	 */
+	void BuildUnicodeMap(std::string raw_cidfont);
+	UNICODE_MAP GetUnicodeMap();
+	const char * GetFontEndianess();
+};
+
+} // !extern "C"
+
+} // !namespace pdfparser
+
+#endif /* FONTS_H_ */

--- a/libs/pdf_font.h
+++ b/libs/pdf_font.h
@@ -1,8 +1,31 @@
-/*
+/*****************************************************************************
  *
- *  Created on: Feb 16, 2018
- *      Author: rodrigo
- */
+ * YEXTEND: Help for YARA users.
+ * This file is part of yextend.
+ *
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
 
 #ifndef FONT_H_
 #define FONT_H_

--- a/libs/pdf_object.cpp
+++ b/libs/pdf_object.cpp
@@ -1,33 +1,19 @@
-/*****************************************************************************
+/*
  *
- * YEXTEND: Help for YARA users.
- * This file is part of yextend.
- *
- * Copyright (c) 2014-2018, Bayshore Networks, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- * the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- * following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
- 
+ *  Created on: Nov 29, 2017
+ *      Author: rodrigo
+ */
+
+/* Include order
+Own .h.
+C.
+C++.
+Other libraries' .h files.
+Your project's .h files.
+*/
 #include "pdf_object.h"
+
+#include <iconv.h>
 
 #include <cstring>
 
@@ -44,447 +30,892 @@
 
 #include <zlib.h>
 
+#include "pdf_font.h"
 #include "pdf_parser_helper.h"
+#include "pdf_text_encoding.h"
+
 
 namespace pdfparser {
-    extern "C" {
-
-        /**
-         * @brief Gets the first pdf object contained in buffer
-         * @param buffer pointer to pdf
-         * @param size size of buffer
-         */
-        PdfObject::PdfObject(const uint8_t* buffer, size_t size){
-
-	        const std::string kObjRegEx = "([0-9]+[[:space:]]+[0-9]+)[[:space:]]+"+kObjBegin+"[[:space:]]+"; // reg_exp.g. '10 0 obj'
-
-	        std::string string_buffer(buffer, buffer+size);
-	        std::regex regexp {kObjRegEx};
-	        std::smatch sm;
-	        std::regex_search (string_buffer, sm, regexp); // Searchs for the begining of an object, reg_exp.g. '10 0 obj'
-
-	        #ifdef DEBUG
-	            std::cout << sm.position(0) << std::endl;
-	            std::cout << sm.str(0) << std::endl;
-	        #endif
-
-	        if (sm.size() > 0) {
-		        auto obj_start = sm.position(0);
-		        auto obj_end = string_buffer.find(kObjEnd);
-		        auto obj_header_size = sm[0].length();
-
-		        id = sm[1];
-
-		        pdf_object = buffer + obj_start;
-		        object_size = obj_end-obj_start;
-		        auto next_item = pdf_object + obj_header_size;
-
-		        if (string_buffer.substr(obj_start + obj_header_size, kDictionaryBegin.size()) == "<<") { //It has a dictionary
-
-			        DictionaryBoundaries dict_boundaries = GetDictionaryBoundaries(pdf_object + obj_header_size,
-					        pdf_object + object_size);
-			        dictionary_start	= dict_boundaries.start;
-			        dictionary_end 		= dict_boundaries.end;
-
-			        UnfoldDictionary(&dictionary, dictionary_start, dictionary_end);
-
-			        GetFilters();
-			        GetStream();
-		        }
-	        }
-	        // There is no more 'obj'
-	        else {
-		        object_size = 0;
-		        pdf_object = buffer + size;
-	        }
-        }
-
-        PdfObject::~PdfObject() {
-	        delete[] decoded_stream;
-        }
-
-        std::string PdfObject::GetId() {
-	        return id;
-        }
-
-        Dictionary* PdfObject::GetDictionary() {
-	        return &dictionary;
-        }
-
-        void  PdfObject::UnfoldDictionary(Dictionary* dictionary, const uint8_t* begin, const uint8_t* end) {
-	        size_t dictionary_index{0};
-
-	        const std::string kKeyRegEx = "([[:w:]-]+)([[:s:]])*(.*)"; // reg_exp.g. '/Key'
-	        const std::string kObjRefRegEx = "^([0-9]+[[:space:]]+[0-9]+)([[:space:]]+R[[:space:]]*)(.*)"; // for indirect object reference '0 5 R'
-	        const std::string kArrayRegEx = "^(\\[.*\\])(.*)";													// for arrays '[zzz yyy]'
-	        const std::string kLiteralRegEx = "^(\\(.*\\))(.*)";													// for literals '(this is a literal)'
-
-
-	        const std::regex key_regex {kKeyRegEx};
-	        const std::regex obj_ref_regex {kObjRefRegEx};
-	        const std::regex array_regex {kArrayRegEx};
-	        const std::regex literal_regex{kLiteralRegEx};
-
-	        std::string last_part(begin, end);				//Dictionary splitted in key and rest
-	        std::string key{};								// Key of dictionary
-
-	        std::smatch sm;
-	        std::regex_search (last_part, sm, key_regex); // Searchs for the begining of an object, reg_exp.g. '10 0 obj'
-	        auto directory_elem = sm.size();
-
-	        while (directory_elem > 1) {
-		        #ifdef DEBUG
-		            std::cout << sm.size() << std::endl;
-		            std::cout << sm.str(0) << std::endl;
-		            std::cout << sm.str(1) << std::endl;
-		            std::cout << sm.str(directory_elem-1) << std::endl;
-		        #endif
-
-		        key = sm.str(1);
-		        last_part = sm.str(directory_elem-1);
-		        dictionary_index = dictionary_index + sm.position(directory_elem-1);
-
-		        // It is a key-dictionary pair
-		        if (last_part.substr(0, kDictionaryBegin.size()) == kDictionaryBegin) { // Contains a dictionary as value
-			        auto dict_bound = GetDictionaryBoundaries(begin + dictionary_index, end);
-			        Dictionary* new_dict = new Dictionary;
-			        UnfoldDictionary(new_dict, dict_bound.start, dict_bound.end);
-			        dictionary->dictionaries[key] = new_dict;
-
-			        dictionary_index = dictionary_index + dict_bound.end - dict_bound.start;
-			        last_part = last_part.substr(dict_bound.end - dict_bound.start, std::string::npos);
-		        } else { // It is a key-value pair
-			        std::smatch sm_key;
-			        std::smatch sm_array;
-			        std::smatch sm_literal;
-			        std::smatch sm_obj_ref;
-
-			        std::regex_search (last_part, sm_key, key_regex);
-			        std::regex_search (last_part, sm_array, array_regex);
-			        std::regex_search (last_part, sm_literal, literal_regex);
-			        std::regex_search (last_part, sm_obj_ref, obj_ref_regex);
-
-			        if (sm_obj_ref.size() > 0) {
-				        sm = sm_obj_ref;
-			        } else if (sm_array.size() > 0) {
-				        sm = sm_array;
-			        } else if (sm_literal.size() > 0) {
-				        sm = sm_literal;
-			        } else if (sm_key.size() > 0){
-				        sm = sm_key;
-			        }
-
-			        directory_elem = sm.size();
-
-			        dictionary->values[key] = sm.str(1);
-
-			        last_part = sm.str(directory_elem-1);
-			        dictionary_index = dictionary_index + sm.position(directory_elem-1);
-		        }
-
-		        std::regex_search (last_part, sm, key_regex);
-		        directory_elem = sm.size();
-	        }
-        }
-
-        void PdfObject::GetFilters() {
-	        const char kDelimiter {'/'};
-
-	        size_t filter_start = FindStringInBuffer (pdf_object, kFilterTagBegin.c_str(), object_size); //Begin of 'Filter' object
-
-	        if (filter_start != std::string::npos) {
-		        filter_start = filter_start + kFilterTagBegin.length();
-		        size_t filter_size = FindStringInBuffer (pdf_object + filter_start, kFilterTagEnd.c_str(), object_size - filter_start);
-
-		        if (filter_size != std::string::npos) {
-			        dictionary_end = pdf_object + filter_start + filter_size;
-
-			        std::string line{(char*)pdf_object, filter_start, filter_size};
-			        auto filters = SplitString(line, kDelimiter);
-
-			        for (size_t i = 0; i<filters.size(); i++) {
-				        if (kFilterDictionary.end() != std::find(kFilterDictionary.begin(), kFilterDictionary.end(), filters[i])) {
-					        this->filters.push_back(filters[i]);
-				        }
-			        }
-		        }
-	        } else {
-		        dictionary_end = pdf_object; // No filter found
-	        }
-        }
-
-        void PdfObject::GetStream() {
-
-	        size_t stream_position = FindStringInBuffer (dictionary_end, kStreamBegin.c_str(), object_size - (dictionary_end - pdf_object)); //Begin of 'stream'
-
-	        if (stream_position != std::string::npos) {
-		        stream_position = stream_position + kStreamBegin.length();
-		        auto stream_buffer = dictionary_end + stream_position;
-
-		        // To comply with 7.3.8.1 of ISO 32000:2008 and get exactly the start of stream to decode
-		        bool correct_syntax = false;
-		        if (memcmp (stream_buffer, kPdfEol1, 1) == 0) {
-			        stream_buffer++;
-			        correct_syntax = true;
-		        } else if (memcmp (stream_buffer, kPdfEol2, 2) == 0) {
-			        stream_buffer = stream_buffer+2;
-			        correct_syntax = true;
-		        }
-
-		        if (correct_syntax) {
-			        size_t stream_size = FindStringInBuffer (stream_buffer, kStreamEnd.c_str(), object_size - (stream_buffer - pdf_object));
-
-			        if (stream_size != std::string::npos) {
-				        // To comply with 7.3.8.1 of ISO 32000:2008 and get exactly the end of stream to decode
-				        correct_syntax = false;
-				        if (memcmp (stream_buffer + stream_size - 2, kPdfEol2, 2) == 0) {
-					        stream_size=stream_size-2;
-					        correct_syntax = true;
-				        } else if (memcmp (stream_buffer + stream_size - 1, kPdfEol1, 1) == 0){
-					        stream_size--;
-					        correct_syntax = true;
-				        }
-
-				        if (correct_syntax){
-					        stream_start = stream_buffer; // TODO Verify value
-					        this->stream_size = stream_size;
-					        stream_end = stream_start + stream_size;
-				        }
-			        }
-		        }
-	        }
-        }
-
-        bool PdfObject::HasStream(){
-            return (stream_size > 0);
-        }
-
-        bool PdfObject::ExtractStream(std::string filter){
-	        #ifdef DEBUG
-    	        std::cout << "applied filter:\n" << filter << std::endl; //Debug
-	        #endif
-
-	        if (filter == "") {
-		        std::vector<uint8_t> temp (stream_start, stream_end);
-		        decoded_stream_vector = temp;
-		        return true;
-	        } else if ((filter.compare("LZWDecode") != 0) || (filter.compare("FlateDecode") != 0)) {
-		        FlateLZWDecode();
-		        return true;
-	        } else {
-		        #ifdef DEBUG
-		        std::cout << "No accepted filter" << std::endl;
-		        #endif
-
-		        decoded_stream_vector = {};
-		        return false;
-	        }
-        }
-
-        void PdfObject::FlateLZWDecode() {
-	        #ifdef DEBUG
-    	        std::cout << "Deflating..." << std::endl; // Debug
-	        #endif
-
-	        size_t outsize = (stream_size)*DEFLATE_BUFFER_MULTIPLIER;
-	        decoded_stream = new uint8_t [outsize]{'\0'};
-
-	        //Now use zlib to inflate. Must be initialized to '\0'
-	        z_stream zstrm{};
-
-	        zstrm.avail_in = stream_size + 1;
-	        zstrm.avail_out = outsize;
-	        zstrm.next_in = (Bytef*)(stream_start);
-	        zstrm.next_out = (Bytef*)decoded_stream;
-
-	        #ifdef DEBUG
-    	        std::cout << "Deflating...2" << std::endl; // DEBUG
-	        #endif
-
-	        int rsti = inflateInit(&zstrm);
-
-	        #ifdef DEBUG
-    	        std::cout << "Deflating...3" << std::endl; // DEBUG
-	        #endif
-
-	        if (rsti == Z_OK) {
-		        #ifdef DEBUG
-    		        std::cout << "Z_OK" << std::endl;
-		        #endif
-
-		        int rst2 = inflate (&zstrm, Z_FINISH);
-
-		        #ifdef DEBUG
-		        std::cout << "rst2 = " << rsti << std::endl;
-		        #endif
-
-		        if (rst2 >= 0) {
-			        //Ok, got something, extract the content:
-			        decoded_stream_size = zstrm.total_out;
-
-			        decoded_stream_vector.assign(decoded_stream, decoded_stream+decoded_stream_size);
-			        #ifdef DEBUG
-			        std::cout << id <<" DECODED content:\n" << decoded_stream << std::endl; // DEBUG
-			        #endif
-		        }
-	        } else {
-		        std::cout << "Z_NOK" << std::endl;
-	        }
-        }
-
-        std::vector<uint8_t> PdfObject::GetDecodedStream(){
-	        return decoded_stream_vector;
-        }
-
-        /**
-         * Extract text from plain stream.
-         *
-         * Uses the decoded_stream as input and puts its result in parsed_text.
-         */
-        void PdfObject::TextParser() { //TODO unbalanced parentesis (escaped chars) and Hexadecimal strings
-	        bool in_text_block = false;		// Indicates when the position is inside a BT/ET block
-	        size_t parenthesis_depth = 0;	// Indicates when the position is inside a block delimited by '(' and ')' (a literal) and its depth
-	        bool escaped_char = false;		// Indicates when the following character is escaped
-
-	        uint8_t buffer[EXTRACT_TEXT_BUFFER_SIZE]{'\0'};
-	        std::string octal_char{};
-
-	        for (size_t i=0; i < decoded_stream_size; i++) {
-		        uint8_t current_char = decoded_stream[i];
-
-		        // Rotate the buffer and stores the previous characters to detect BT and ET
-		        buffer[0] = buffer[1];
-		        buffer[1] = current_char;
-
-		        // If not in BT/ET check if it is a start of BT/ET (000)->(100) [in_text_block, parentesis_depth, escaped]
-		        if (!in_text_block && (memcmp(buffer, TEXT_BLOCK_START, 2) == 0)) {
-			        in_text_block = true;
-                } else if (in_text_block) {
-			        if (parenthesis_depth == 0) {
-				        // Start of literal '(' (100)->(110)
-				        if (current_char == '(') {
-					        parenthesis_depth++;
-				        } else if (memcmp(buffer, TEXT_BLOCK_END, 2) == 0) { // End of BT/ET (100)->(000)
-					        in_text_block = false;
-				        }
-			        } else if (parenthesis_depth > 0) { // Already inside a literal (110) or (111)
-				        if (escaped_char && octal_char.empty()) {
-					        if (isdigit(current_char)) {
-						        octal_char.push_back(current_char);
-					        } else {
-						        escaped_char = false;
-
-						        if (current_char == 'n') {
-							        parsed_text.push_back('\n');}
-
-						        else if (current_char == 'r') {
-							        parsed_text.push_back('\r');}
-
-						        else if (current_char == 't') {
-							        parsed_text.push_back('\t');}
-
-						        else if (current_char == 'b'){
-							        parsed_text.push_back('\b');}
-
-						        else if (current_char == 'f'){
-							        parsed_text.push_back('\f');}
-
-						        else if (current_char == '\\'){
-							        parsed_text.push_back('\\');}
-
-						        else if (current_char == '('){
-							        parsed_text.push_back('(');}
-
-						        else if (current_char == ')'){
-							        parsed_text.push_back(')');}
-					        }
-				        } else {
-					        // Escaped and octal
-					        if (!octal_char.empty()) {
-						        if (octal_char.size() == 3 || !isdigit(current_char)) {
-							        escaped_char = false;
-							        uint8_t actual_char = static_cast<uint8_t>(std::stoi(octal_char));
-							        parsed_text.push_back(actual_char);
-							        octal_char.erase();
-						        } else {
-							        octal_char.push_back(current_char);
-						        }
-					        }
-
-					        // Not escaped
-					        if (!escaped_char) {
-						        if (current_char == '\\') {
-							        escaped_char = true;
-						        } else {
-							        if (current_char == '(') {
-								        parenthesis_depth++;
-							        } else if (current_char == ')') {
-								        parenthesis_depth--;
-							        }
-
-							        if (parenthesis_depth > 0) {
-								        parsed_text.push_back(current_char);
-							        }
-						        }
-					        }
-				        }
-			        }
-		        }
-	        }
-
-	        #ifdef DEBUG
-	            std::string output(parsed_text.begin(), parsed_text.end()); // DEBUG
-	            std::cout << "output:\n" << output << std::endl << std::flush; // DEBUG
-	        #endif
-        }
-
-        std::vector<uint8_t> PdfObject::GetParsedText(){
-        	return parsed_text;
-        }
-
-        //start of 'obj' + size of 'obj' + length of flag
-        const uint8_t* PdfObject::GetObjectEnd() {
-	        if (object_size == 0) {
-		        return pdf_object;
-	        } else {
-		        return pdf_object + object_size + kObjEnd.length();
-	        }
-        }
-
-        /**
-         * @brief	Detects the limits of the outer dictionary between the limits provided
-         * @param begin
-         * @param end
-         */
-        DictionaryBoundaries PdfObject::GetDictionaryBoundaries (const uint8_t* begin, const uint8_t* end) {
-	        std::string string_buffer(begin, end);
-
-	        auto dict_begin = string_buffer.find(kDictionaryBegin);
-	        DictionaryBoundaries dict_bound{};
-	        dict_bound.start =  begin + dict_begin;
-
-	        size_t last_dictionary_position{dict_begin+kDictionaryBegin.size()};	// Two chars '<<' as the first dictionary begin
-	        size_t dictionaries_counter{1};								// It has at least 1 dictionary
-	        auto dictionaries_quantity = dictionaries_counter;			// Dictionary blocks present
-	        auto dictionary_size = end - begin;							// Not necessarily the dictionary itself, but a limit to search
-
-	        while ((last_dictionary_position < dictionary_size) && (dictionaries_counter > 0)) {
-		        if (string_buffer.substr(dict_begin + last_dictionary_position, kDictionaryBegin.size()) == kDictionaryBegin) {
-			        last_dictionary_position = last_dictionary_position + 2;
-			        ++dictionaries_counter;
-			        ++dictionaries_quantity;
-		        } else if (string_buffer.substr(dict_begin + last_dictionary_position, kDictionaryEnd.size()) == kDictionaryEnd) {
-			        last_dictionary_position = last_dictionary_position + 2;
-			        --dictionaries_counter;
-		        } else {
-			        ++last_dictionary_position;
-		        }
-	        }
-	        dict_bound.end = begin + last_dictionary_position;
-
-	        return dict_bound;
-        }
-
-    } // !extern "C"
+
+
+extern "C" {
+
+
+PdfObject::PdfObject() {
+
+}
+
+
+/**
+ * @brief Gets the first pdf object contained in buffer
+ * @param buffer pointer to pdf
+ * @param size size of buffer
+ */
+PdfObject::PdfObject(const uint8_t* buffer, size_t size){
+
+	const std::string kObjRegEx = "([0-9]+[[:space:]]+[0-9]+)[[:space:]]+"+kObjBegin+"[[:space:]]+"; // reg_exp.g. '10 0 obj'
+
+	std::string string_buffer(buffer, buffer+size);
+	std::regex regexp {kObjRegEx};
+	std::smatch sm;
+	std::regex_search (string_buffer, sm, regexp); // Searchs for the begining of an object, reg_exp.g. '10 0 obj'
+
+	#ifdef DEBUG
+	std::cout << sm.position(0) << std::endl; // Debug
+	std::cout << sm.str(0) << std::endl; // Debug
+	#endif
+
+	if (sm.size() > 0) {
+	//size_t obj_start = FindStringInBuffer (buffer, kObjStart.c_str(), size); //Begin of 'obj' object
+	//if (obj_start != std::string::npos){
+		auto obj_start = sm.position(0);
+		auto obj_end = string_buffer.find(kObjEnd);
+		auto obj_header_size = sm[0].length();
+
+		id = sm[1];
+
+		pdf_object = buffer + obj_start;
+		object_size = obj_end-obj_start;
+		auto next_item = pdf_object + obj_header_size;
+
+		if (string_buffer.substr(obj_start + obj_header_size, kDictionaryBegin.size()) == "<<") { //It has a dictionary
+
+			DictionaryBoundaries dict_boundaries = GetDictionaryBoundaries(pdf_object + obj_header_size,
+					pdf_object + object_size);
+			dictionary_start	= dict_boundaries.start;
+			dictionary_end 		= dict_boundaries.end;
+
+			UnfoldDictionary(&dictionary, dictionary_start, dictionary_end);
+			GetFilters();
+			GetStream();
+		}
+	}
+	// There is no more 'obj'
+	else {
+		object_size = 0;
+		pdf_object = buffer + size;
+	}
+}
+
+
+PdfObject::~PdfObject(){
+	delete[] decoded_stream;
+//	if (dictionary.dictionaries.size() > 0)
+//		DeleteDictionary(&dictionary);
+}
+
+
+/*
+void PdfObject::DeleteDictionary(Dictionary* dictionary){
+	for (auto x: dictionary->dictionaries) {
+		DeleteDictionary(x.second);
+		delete x.second;
+	}
+}
+*/
+
+
+std::string PdfObject::GetId() {
+	return id;
+}
+
+
+Dictionary* PdfObject::GetDictionary() {
+	return &dictionary;
+}
+
+
+void  PdfObject::UnfoldDictionary(Dictionary* dictionary, const uint8_t* begin, const uint8_t* end) { //TODO
+
+	auto dictionary_begin = begin+kDictionaryBegin.size();
+
+	size_t dictionary_index{0};
+
+	//const std::string kObjectBegin = R("^([0-9]+\s+[0-9]+\s+obj)(\s*)([\s\S]*))"; // Obj '15 0 obj'
+	//const std::string kNameRegEx 	= R"(^(/[^\x00-\x20\(\)\<\>\[\]\{\}/\%\x7f-\xff]+)(\s*)([\s\S]*))";	// Name objects /Key1+3 Optimal TODO
+	const std::string kBoolRegEx	= R"(^(true|false)\s*([\s\S]*))";				// Boolean true or false
+	const std::string kNameRegEx 	= R"(^(/[[:w:]\+\-]+)\s*([\s\S]*))";			// Name objects /Key1+3
+	const std::string kObjRefRegEx 	= R"(^([0-9]+\s+[0-9]+)\s+R\s*([\s\S]*))";		// Indirect object reference '0 5 R'
+	// V0 const std::string kArrayRegEx 	= R"(^(\[.*\])([\s\S]*))";				// Arrays '[zzz yyy]'
+	const std::string kArrayRegEx 	= R"(^(\[[[:alnum:]\+\-/\R\s]+\])\s*([\s\S]*))";// Arrays '[zzz yyy]'
+	const std::string kLiteralRegEx = R"(^(\(.*\))\s*([\s\S]*))";					// Literals '(this is a literal)'
+	const std::string kLiteralHexRegEx = R"(^(<[[:xdigit:]]+>)\s*([\s\S]*))";		// Literals in hexa '<FEFF0054>'
+	const std::string kNumberRegEx	= R"(^([\+-]?[0-9]*\.?[0-9]*)\s*([\s\S]*))";	// Numbers 33 +33 -33 0.4 .4 +0.4 +.4
+
+	const std::regex bool_regex {kBoolRegEx};
+	const std::regex name_regex {kNameRegEx};
+	const std::regex obj_ref_regex {kObjRefRegEx};
+	const std::regex array_regex {kArrayRegEx};
+	const std::regex literal_regex {kLiteralRegEx};
+	const std::regex literal_hex_regex {kLiteralHexRegEx};
+	const std::regex number_regex {kNumberRegEx};
+
+	std::string last_part(dictionary_begin, end);	//Dictionary splitted in key and rest
+
+	std::smatch sm;
+	std::regex_search (last_part, sm, name_regex); // Searches for the beginning of an key /key
+	auto directory_elem = sm.size();
+
+	while (directory_elem > 1) {
+
+		std::string key = sm.str(1); // It is the key of key-value pair
+		last_part = sm.str(directory_elem-1);
+		dictionary_index = dictionary_index + sm.position(directory_elem-1); //to the next char after key
+
+#ifdef DEBUG
+		if ((id == "4 0" && true) || (id == "1 0" && false)) {
+			std::cout << "DEBUG" << std::endl;
+		}
+		std::cout << "\nPDF Object: " << id << ". Elements of sm: "<< directory_elem << std::endl;
+		//std::cout << "Element 0: " << sm.str(0) << std::endl; // All matches
+		std::cout << "Key: " << key << std::endl;
+		//std::cout << "Last elem(rest): " << sm.str(directory_elem-1) << std::endl;
+#endif
+
+		// It is a key-dictionary pair
+		if (last_part.substr(0, kDictionaryBegin.size()) == kDictionaryBegin) { // Contains a dictionary as value
+			auto dict_bound = GetDictionaryBoundaries(dictionary_begin + dictionary_index, end);
+			Dictionary* new_dict = new Dictionary;
+			UnfoldDictionary(new_dict, dict_bound.start, dict_bound.end);
+			dictionary->dictionaries[key] = new_dict;
+
+			dictionary_index = dictionary_index + dict_bound.end - dict_bound.start;
+
+			// Advances to the next key
+			auto next_key = last_part.find(kNameTagBegin, dict_bound.end - dict_bound.start);
+			if (next_key < std::string::npos) {
+				// There is still dictionary
+				last_part = last_part.substr(next_key, std::string::npos);
+			}
+			else{
+				//No more dictionary to search in
+				last_part = "";
+			}
+		}
+		// It is a key-value pair
+		else {
+			std::smatch sm_bool;
+			std::smatch sm_name;
+			std::smatch sm_array;
+			std::smatch sm_literal;
+			std::smatch sm_literal_hex;
+			std::smatch sm_obj_ref;
+			std::smatch sm_number;
+
+			std::regex_search (last_part, sm_bool, bool_regex);
+			std::regex_search (last_part, sm_name, name_regex);
+			std::regex_search (last_part, sm_array, array_regex);
+			std::regex_search (last_part, sm_literal, literal_regex);
+			std::regex_search (last_part, sm_literal_hex, literal_hex_regex);
+			std::regex_search (last_part, sm_obj_ref, obj_ref_regex);
+			std::regex_search (last_part, sm_number, number_regex);
+
+			if (sm_bool.size() > 0) {
+				sm = sm_bool;
+			}
+			else if (sm_obj_ref.size() > 0) {
+				sm = sm_obj_ref;
+			}
+			else if (sm_array.size() > 0) {
+				sm = sm_array;
+			}
+			else if (sm_literal.size() > 0) {
+				sm = sm_literal;
+			}
+			else if (sm_literal_hex.size() > 0) {
+				sm = sm_literal_hex;
+			}
+			else if (sm_name.size() > 0) {
+				sm = sm_name;
+			}
+			else if (sm_number.size() > 0) {
+				sm = sm_number;
+			}
+
+			directory_elem = sm.size();
+
+#ifdef DEBUG
+			//std::cout << "String: " << last_part << std::endl;
+			//std::cout << "Elements of sm: "<< directory_elem << std::endl;
+			//std::cout << "Element 0: " << sm.str(0) << std::endl; // All matches
+			std::cout << "Element 1: " << sm.str(1) << std::endl;
+			//std::cout << "Last elem(rest): " << sm.str(directory_elem-1) << std::endl;
+#endif
+
+			auto value = sm.str(1);
+			std::replace(value.begin(), value.end(), '\n', ' '); // Replace \n by space
+			dictionary->values[key] = value;
+
+			last_part = sm.str(directory_elem-1);
+			dictionary_index = dictionary_index + sm.position(directory_elem-1);
+		}
+		std::regex_search (last_part, sm, name_regex);
+		directory_elem = sm.size();
+	}
+}
+
+
+void PdfObject::GetFilters() {
+	const char kDelimiter {'/'};
+
+	// It has filters
+	if (dictionary.values.find(kFilterTagBegin) != dictionary.values.end()) {
+		auto filters_buffer = dictionary.values[kFilterTagBegin];
+
+		// If it is an array TODO verify the case of array
+		if (filters_buffer.substr(0, kArrayTagBegin.size()) == kArrayTagBegin) {
+			auto filters_array = SplitString(filters_buffer, kDelimiter);
+
+			//filters.insert(filters.end(), filters_array.begin(), filters_array.end());
+			for (auto x: filters_array) {
+				filters.push_back(kDelimiter+x);
+			}
+		}
+
+		// It is not an array -> single value
+		else {
+			filters.push_back(filters_buffer);
+		}
+	}
+
+	// No filter found
+
+	/*
+	const char kDelimiter {'/'};
+
+	size_t filter_start = FindStringInBuffer (pdf_object, kFilterTagBegin.c_str(), object_size); //Begin of 'Filter' object
+
+	if (filter_start != std::string::npos){
+		filter_start = filter_start + kFilterTagBegin.length();
+		size_t filter_size = FindStringInBuffer (pdf_object + filter_start, kFilterTagEnd.c_str(), object_size - filter_start);
+
+		if (filter_size != std::string::npos){
+			dictionary_end = pdf_object + filter_start + filter_size;
+
+			std::string line{(char*)pdf_object, filter_start, filter_size};
+			auto filters = SplitString(line, kDelimiter);
+
+			for (size_t i = 0; i<filters.size(); i++) {
+				if (kFilterDictionary.end() != std::find(kFilterDictionary.begin(), kFilterDictionary.end(), filters[i])) {
+					this->filters.push_back(filters[i]);
+				}
+			}
+		}
+	}
+	else {
+		dictionary_end = pdf_object; // No filter found
+	}
+	*/
+}
+
+
+void PdfObject::GetStream(){
+
+	size_t stream_position = FindStringInBuffer (dictionary_end, kStreamBegin.c_str(), object_size - (dictionary_end - pdf_object)); //Begin of 'stream'
+	
+	if (stream_position != std::string::npos){
+		stream_position = stream_position + kStreamBegin.length();
+		auto stream_buffer = dictionary_end + stream_position;
+
+		// To comply with 7.3.8.1 of ISO 32000:2008 and get exactly the start of stream to decode
+		bool correct_syntax = false;
+		if (memcmp (stream_buffer, kPdfEol1, 1) == 0) {
+			stream_buffer++;
+			correct_syntax = true;
+		}
+		else if (memcmp (stream_buffer, kPdfEol2, 2) == 0){
+			stream_buffer = stream_buffer+2;
+			correct_syntax = true;
+		}
+
+		if (correct_syntax){
+			size_t stream_size = FindStringInBuffer (stream_buffer, kStreamEnd.c_str(), object_size - (stream_buffer - pdf_object));
+
+			if (stream_size != std::string::npos){
+				// To comply with 7.3.8.1 of ISO 32000:2008 and get exactly the end of stream to decode
+				correct_syntax = false;
+				if (memcmp (stream_buffer + stream_size - 2, kPdfEol2, 2) == 0) {
+					stream_size=stream_size-2;
+					correct_syntax = true;
+				}
+				else if (memcmp (stream_buffer + stream_size - 1, kPdfEol1, 1) == 0){
+					stream_size--;
+					correct_syntax = true;
+				}
+
+				if (correct_syntax){
+					stream_start = stream_buffer; // TODO Verify value
+					this->stream_size = stream_size;
+					stream_end = stream_start + stream_size;
+				}
+			}
+		}
+	}
+}
+
+
+bool PdfObject::HasStream(){
+	if (stream_size > 0) return true;
+	else return false;
+}
+
+
+bool PdfObject::ExtractStream(std::string filter){
+
+#ifdef DEBUG
+	std::cout << "\n### DEBUG PdFObject::ExtractStream ###\nApplied filter: " << filter << std::endl; //Debug
+#endif
+
+	// It has no filter, so the stream is no encoded
+	if (filter == "") {
+		std::vector<uint8_t> temp (stream_start, stream_end);
+		decoded_stream_vector = temp;
+		return true;
+	}
+	else if ((filter.compare("LZWDecode") != 0) || (filter.compare("FlateDecode") != 0)) {
+		FlateLZWDecode();
+		return true;
+	}
+	else {
+		#ifdef DEBUG
+		std::cout << "No accepted filter" << std::endl;
+		#endif
+
+		decoded_stream_vector = {};
+		return false;
+	}
+}
+
+
+void PdfObject::FlateLZWDecode() {
+
+#ifdef DEBUG
+	std::cout << "\n### DEBUG PdfObject::FlateLZWDecode ###\n" << std::endl; // Debug
+#endif
+
+	size_t outsize = (stream_size)*DEFLATE_BUFFER_MULTIPLIER;
+	decoded_stream = new uint8_t [outsize]{'\0'};
+
+	//Now use zlib to inflate. Must be initialized to '\0'
+	z_stream zstrm{};
+
+	zstrm.avail_in = stream_size + 1;
+	zstrm.avail_out = outsize;
+	zstrm.next_in = (Bytef*)(stream_start);
+	zstrm.next_out = (Bytef*)decoded_stream;
+
+	int rsti = inflateInit(&zstrm);
+
+	if (rsti == Z_OK)
+	{
+		int rst2 = inflate (&zstrm, Z_FINISH);
+
+		if (rst2 >= 0)
+		{
+			//Ok, got something, extract the content:
+			decoded_stream_size = zstrm.total_out;
+			decoded_stream_vector.assign(decoded_stream, decoded_stream+decoded_stream_size);
+
+#ifdef DEBUG
+			std::cout << "Obj: " << id <<" Deflating Ok. DECODED content:\n" << decoded_stream << std::endl;
+#endif
+		}
+	}
+	else {
+#ifdef DEBUG
+		std::cout << "Z_NOK" << std::endl;
+#endif
+	}
+}
+
+
+std::vector<uint8_t> PdfObject::GetDecodedStream(){
+	return decoded_stream_vector;
+}
+
+
+/**
+ * Extract text from plain stream.
+ *
+ * Uses the decoded_stream as input and puts its result in parsed_plain_text.
+ */
+//TODO Hexadecimal strings
+void PdfObject::ParseText(std::map<std::string, Font>& fonts){
+
+	bool in_text_block = false;			// Indicates when the position is inside a BT/ET block
+	size_t parenthesis_depth = 0;		// Indicates when the position is inside a block delimited by '(' and ')' (a literal) and its depth. It shall be printed with Tj
+	size_t square_brackets_depth = 0;	// Indicates when the position is inside a array. It shall be printed with TJ
+	bool escaped_char = false;			// Indicates when the following character is escaped
+
+	uint8_t current_char{'\0'};
+	uint8_t buffer[EXTRACT_TEXT_BUFFER_SIZE]{'\0'};
+
+	std::string octal_char{};
+	std::string text_buffer{};	// Stores temporally the text to be parsed later on
+	std::string local_font{};	// Local font in BT/ET
+
+	size_t decoded_stream_idx=0;
+	while (decoded_stream_idx < decoded_stream_size) {
+		current_char = decoded_stream[decoded_stream_idx++];
+
+		// Rotate the buffer and stores the previous characters to detect BT and ET
+		for (unsigned char j=0; j<EXTRACT_TEXT_BUFFER_SIZE-1; ++j) {
+			buffer[j] = buffer[j+1];
+		}
+		buffer[EXTRACT_TEXT_BUFFER_SIZE-1] = current_char;
+		std::string buffer_str (buffer, buffer+EXTRACT_TEXT_BUFFER_SIZE);
+
+		// If not in BT/ET check if it is a start of BT/ET (000)->(100) [in_text_block, parentesis_depth, escaped]
+		if (!in_text_block && (memcmp(buffer, TEXT_BLOCK_START, 2) == 0)) {
+			in_text_block = true;}
+
+		// Inside BT/ET block
+		else if (in_text_block) {
+
+			if (parenthesis_depth == 0 && square_brackets_depth == 0) {
+
+				// Font selector
+				if (memcmp(buffer, TEXT_FONT, 2) == 0){
+					local_font = TEXT_FONT;
+
+					auto from = reinterpret_cast<const char *>(&decoded_stream[decoded_stream_idx]);
+					auto to = from + TEXT_FONT_MAX_SIZE;
+
+					std::string font_buffer(from, to);
+
+					// Searchs for the name of the font
+					const std::regex re {R"(^([[:w:]]+)\s)"};
+					std::smatch sm;
+					std::regex_search (font_buffer, sm, re);
+					local_font += sm.str(1);
+
+					// ATTN idx is also incremented here. Buffer becomes corrupted with no impact in parsing
+					decoded_stream_idx += sm.str(1).size();
+				}
+
+				// TJ received, array buffer has info then parse text array. Nomultilevel arrays allowed
+				else if ((memcmp(buffer, TEXT_PRINT_ARRAY, 2) == 0) && (text_buffer.size() > 0)){
+					auto font = fonts[local_font];
+					ParseTextArray(text_buffer, font);
+					text_buffer.clear();
+				}
+
+				// Operator resets array and literal buffer
+				else if (std::find(kTextResetingOperators.begin(), kTextResetingOperators.end(), buffer_str)
+				!= kTextResetingOperators.end()) {
+					text_buffer.clear();
+				}
+
+				// Start of literal '(' (100)->(110)
+				else if (current_char == '(') {
+					++parenthesis_depth;
+				}
+
+				else if (current_char == '[') {
+					++square_brackets_depth;
+				}
+
+				// End of BT/ET (100)->(000)
+				else if (memcmp(buffer, TEXT_BLOCK_END, 2) == 0){
+					in_text_block = false;
+					local_font.clear();
+					text_buffer.clear();
+				}
+			}
+
+			// Inside of an array
+			else if (square_brackets_depth > 0) {
+				if (current_char == ']') {
+					--square_brackets_depth;
+				}
+				else if (current_char == '[') {
+					++square_brackets_depth;
+				}
+				else text_buffer += current_char;
+			}
+
+			//  Already inside a literal (110) or (111). TODO reshape with parenthesis parser.
+			else if (parenthesis_depth > 0){
+
+				if (escaped_char && octal_char.empty()) {
+					if (isdigit(current_char)){
+						octal_char.push_back(current_char);
+					}
+
+					else {
+						escaped_char = false;
+
+						if (current_char == 'n') {
+							parsed_plain_text.push_back('\n');}
+
+						else if (current_char == 'r') {
+							parsed_plain_text.push_back('\r');}
+
+						else if (current_char == 't') {
+							parsed_plain_text.push_back('\t');}
+
+						else if (current_char == 'b'){
+							parsed_plain_text.push_back('\b');}
+
+						else if (current_char == 'f'){
+							parsed_plain_text.push_back('\f');}
+
+						else if (current_char == '\\'){
+							parsed_plain_text.push_back('\\');}
+
+						else if (current_char == '('){
+							parsed_plain_text.push_back('(');}
+
+						else if (current_char == ')'){
+							parsed_plain_text.push_back(')');}
+					}
+				}
+
+				else {
+					// Escaped and octal
+					if (!octal_char.empty()) {
+
+						if (octal_char.size() == 3 || !isdigit(current_char)) {
+							escaped_char = false;
+							uint8_t actual_char = static_cast<uint8_t>(std::stoi(octal_char));
+							parsed_plain_text.push_back(actual_char);
+							octal_char.erase();
+						}
+						else {
+							octal_char.push_back(current_char);
+						}
+					}
+
+					// Not escaped
+					if (!escaped_char){
+
+						if (current_char == '\\'){
+							escaped_char = true;
+						}
+
+						else {
+							if (current_char == '(') {
+								parenthesis_depth++;
+							}
+							else if (current_char == ')') {
+								parenthesis_depth--;
+							}
+
+							if (parenthesis_depth > 0) {
+								parsed_plain_text.push_back(current_char);
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+
+std::vector<uint8_t> PdfObject::GetParsedPlainText(TextEncoding encoding){
+	if (encoding == TextEncoding::utf8) {
+		std::vector<uint8_t> utf8_text(parsed_plain_text_utf8.begin(), parsed_plain_text_utf8.end());
+		return utf8_text;
+	}
+	else {
+		return parsed_plain_text;
+	}
+}
+
+/**
+ * @brief	 start of 'obj' + size of 'obj' + length of flag
+ * @return
+ */
+const uint8_t* PdfObject::GetObjectEnd() {
+	if (object_size == 0) {
+		return pdf_object;
+	}
+	else {
+		return pdf_object + object_size + kObjEnd.length();
+	}
+}
+
+
+/**
+ * @brief	Detects the limits of the outer dictionary between the limits provided
+ * @param begin
+ * @param end
+ */
+DictionaryBoundaries PdfObject::GetDictionaryBoundaries (const uint8_t* begin, const uint8_t* end) {
+
+	std::string string_buffer(begin, end);
+
+	auto dict_begin = string_buffer.find(kDictionaryBegin);
+	DictionaryBoundaries dict_bound{};
+	dict_bound.start =  begin + dict_begin;
+
+	size_t last_dictionary_position{dict_begin+kDictionaryBegin.size()}; // Advances chars quantity of '<<' as the first dictionary begin
+	size_t dictionaries_counter{1};						// Index of dictionaries. It is already inside the first
+	auto dictionary_size = end - begin;					// Not necessarily the dictionary itself, but a limit to search
+
+	// Sweeps dictionary counting inner dictionaries
+	while ((last_dictionary_position < dictionary_size) && (dictionaries_counter > 0)) {
+		if (string_buffer.substr(dict_begin + last_dictionary_position, kDictionaryBegin.size()) == kDictionaryBegin) {
+			last_dictionary_position += 2;
+			++dictionaries_counter;
+		}
+		else if (string_buffer.substr(dict_begin + last_dictionary_position, kDictionaryEnd.size()) == kDictionaryEnd) {
+			last_dictionary_position += 2;
+			--dictionaries_counter;
+		}
+		else {
+			++last_dictionary_position;
+		}
+	}
+	dict_bound.end = begin + last_dictionary_position;
+
+	return dict_bound;
+}
+
+
+std::string PdfObject::ExtractFontDefinition(Dictionary* dictionary) {
+	bool font_found{false};
+	std::string font_definition{""};
+
+	auto values = dictionary->values;
+
+	// check if the value is a indirect reference
+	if (values.find(kFontTagBegin) != values.end()) {
+		font_found = true;
+		font_definition = dictionary->values[kFontTagBegin];
+		}
+
+	// If not and there are dictionaries check them
+	else if (dictionary->dictionaries.size() != 0) {
+		auto subdictionary = dictionary->dictionaries; //map
+
+		// If the no dictionary key is not Font, analyze insider dictionaries
+		if (subdictionary.find(kFontTagBegin) == subdictionary.end()) {
+
+			auto subdictionary_iterator = subdictionary.begin();
+			while (!font_found && (subdictionary_iterator != subdictionary.end())) {
+
+				font_definition = ExtractFontDefinition(subdictionary_iterator->second); // pass the dictionary associated
+
+				if (font_definition.size() > 0) {
+					font_found = true;
+				}
+				else {
+					std::advance(subdictionary_iterator, 1);
+				}
+			}
+		}
+		else { // Font definition is stored in a dictionary
+			font_definition =  subdictionary[kFontTagBegin]->IndirectReference();
+		}
+	}
+
+	return font_definition;
+}
+
+
+void PdfObject::ParseTextArray(std::string& array, Font& font) {
+	//TESTME empty font
+	std::vector<uint8_t> parsing_buffer{};
+	auto unicode_map = font.GetUnicodeMap();
+
+	auto it = array.begin();
+	while (it != array.end()){
+
+		// Inside a hexadecimal char
+		if (*it == '<') {
+			bool is_hexa = true;
+
+			++it;
+			while (is_hexa && it != array.end()) {
+
+				if (*(it) == '>') {
+					is_hexa = false;
+					//++it;
+				}
+				else {
+					std::string cid(it, it+2);
+#ifdef DEBUG
+					if ((cid == "35") || (cid == "27") || (cid == "28")) {
+						//std::cout << "DEBUG\n";
+					}
+#endif
+					//parsed_plain_text.push_back(unicode_map[cid]); //TESTME empty map
+					parsing_buffer.insert(parsing_buffer.end(),
+							unicode_map[cid].begin(),
+							unicode_map[cid].end()); //TESTME empty map
+
+					it+=2;
+				}
+			}
+		}
+		//There is literal text inside the array
+		else if (*it == '(') {
+			// Detect end of literal
+
+			++it;
+			auto literal_it_end = it;
+			bool is_literal_end {false};
+			while (!is_literal_end && (literal_it_end != array.end())) {
+
+				// It's an escaped character, the following one shall be skipped (to be processed in TextParse)
+				// For example for the case of \(
+				if (*literal_it_end == '\\') {
+					literal_it_end +=2;
+				}
+				else if (*literal_it_end == ')') {
+						is_literal_end = true;
+				}
+				else {
+					++literal_it_end;
+				}
+			}
+			std::string literal_to_parse(it, literal_it_end);
+
+			auto literal_parsed = ParseTextLiteral(literal_to_parse);
+			parsing_buffer.insert(parsing_buffer.end(), literal_parsed.begin(), literal_parsed.end());
+
+			it = literal_it_end;
+		}
+
+		++it;
+	}
+
+	// Finished parsing. Convert to utf8 for displaying purpouses
+	size_t max_out_buffer = parsing_buffer.size() * 3 + 1;
+	std::vector<char> out_buffer(max_out_buffer);
+
+	iconv_t converter = iconv_open("UTF-8", font.GetFontEndianess());
+	auto from_ptr = reinterpret_cast<char *>(parsing_buffer.data());
+	auto to_ptr = out_buffer.data();
+	//char *to_ptr = &(out_buffer[0]);
+
+	size_t in_remaining_buffer = parsing_buffer.size();
+	size_t out_remaining_buffer = max_out_buffer;
+
+	iconv(converter, &from_ptr, &in_remaining_buffer, &to_ptr, &out_remaining_buffer);
+	auto out_buffer_used = max_out_buffer-out_remaining_buffer;
+
+	// Stores text in original format
+	parsed_plain_text.insert(parsed_plain_text.end(), parsing_buffer.begin(), parsing_buffer.end());
+
+	// Stores text in utf8
+	parsed_plain_text_utf8.append(&out_buffer[0], out_buffer_used);
+	iconv_close(converter);
+
+#ifdef DEBUG
+	std::cout << "\nParsed UTF-8 text\n " << parsed_plain_text_utf8.data() << '\n';
+	std::cout << "\nParsed raw text\n" << parsed_plain_text.data() << '\n';
+#endif
+
+	/*
+	std::wstring_convert<std::codecvt_utf8_utf16<char16_t>,char16_t> conversion;
+	std::u16string u16(parsed_plain_text.begin(), parsed_plain_text.end());
+	auto output1 = conversion.to_bytes(u16);
+*/
+}
+
+
+std::string PdfObject::ParseTextLiteral(std::string& text){
+
+	std::string parsed_literal{};
+	std::string octal_char{};
+
+	bool escaped_char = false;
+
+	auto it = text.begin();
+	while (it != text.end()) {
+
+		// Escaped and octal
+		if (escaped_char && octal_char.empty()) {
+
+			// It is an octal. Accumulate digits in octal buffer
+			if (isdigit(*it)){
+				octal_char.push_back(*it);
+			}
+
+			// It is an escaped char but not an octal
+			else {
+				escaped_char = false;
+
+				if (*it == 'n') {
+					parsed_literal.push_back('\n');}
+
+				else if (*it == 'r') {
+					parsed_literal.push_back('\r');}
+
+				else if (*it == 't') {
+					parsed_literal.push_back('\t');}
+
+				else if (*it == 'b'){
+					parsed_literal.push_back('\b');}
+
+				else if (*it == 'f'){
+					parsed_literal.push_back('\f');}
+
+				// *it == '\\' || *it == '(' *it == ')'
+				else {
+					parsed_literal.push_back(*it);
+				}
+			}
+		}
+
+		// Escaped or octal
+		else {
+			// Octal
+			if (!octal_char.empty()) {
+
+				if (octal_char.size() == 3 || !isdigit(*it)) {
+					escaped_char = false;
+					auto actual_char = static_cast<uint8_t>(std::stoi(octal_char));
+					parsed_literal.push_back(actual_char);
+					octal_char.erase();
+				}
+				else {
+					octal_char.push_back(*it);
+				}
+			}
+
+			// Not escaped
+			if (!escaped_char){
+
+				if (*it == '\\'){
+					escaped_char = true;
+				}
+				else {
+					parsed_literal.push_back(*it);
+				}
+			}
+		}
+
+		++it;
+	}
+	return parsed_literal;
+}
+
+
+/**
+ * @brief	Returns a dictionary in the form "<</key value>>" to be parsed elsewhere
+ * @return
+ */
+std::string Dictionary::IndirectReference() {
+	std::string buffer{kDictionaryBegin};
+
+	// TODO Manage many fonts in the same
+	for (auto value: values) {
+		buffer = buffer + value.first + " " + value.second + " R ";
+	}
+
+	// Eliminates the trailing space
+	buffer.resize(buffer.size()-1);
+	buffer.append(kDictionaryEnd);
+
+	return buffer;
+}
+
+
+} // !extern "C"
 
 } // !namespace pdfparser
+

--- a/libs/pdf_object.cpp
+++ b/libs/pdf_object.cpp
@@ -438,6 +438,10 @@ namespace pdfparser {
 	        #endif
         }
 
+        std::vector<uint8_t> PdfObject::GetParsedText(){
+        	return parsed_text;
+        }
+
         //start of 'obj' + size of 'obj' + length of flag
         const uint8_t* PdfObject::GetObjectEnd() {
 	        if (object_size == 0) {

--- a/libs/pdf_object.cpp
+++ b/libs/pdf_object.cpp
@@ -1,0 +1,486 @@
+/*****************************************************************************
+ *
+ * YEXTEND: Help for YARA users.
+ * This file is part of yextend.
+ *
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+ 
+#include "pdf_object.h"
+
+#include <cstring>
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <istream>
+#include <iostream> //debugging
+#include <list>
+#include <regex>
+#include <string>
+#include <sstream>
+#include <vector>
+
+#include <zlib.h>
+
+#include "pdf_parser_helper.h"
+
+namespace pdfparser {
+    extern "C" {
+
+        /**
+         * @brief Gets the first pdf object contained in buffer
+         * @param buffer pointer to pdf
+         * @param size size of buffer
+         */
+        PdfObject::PdfObject(const uint8_t* buffer, size_t size){
+
+	        const std::string kObjRegEx = "([0-9]+[[:space:]]+[0-9]+)[[:space:]]+"+kObjBegin+"[[:space:]]+"; // reg_exp.g. '10 0 obj'
+
+	        std::string string_buffer(buffer, buffer+size);
+	        std::regex regexp {kObjRegEx};
+	        std::smatch sm;
+	        std::regex_search (string_buffer, sm, regexp); // Searchs for the begining of an object, reg_exp.g. '10 0 obj'
+
+	        #ifdef DEBUG
+	            std::cout << sm.position(0) << std::endl;
+	            std::cout << sm.str(0) << std::endl;
+	        #endif
+
+	        if (sm.size() > 0) {
+		        auto obj_start = sm.position(0);
+		        auto obj_end = string_buffer.find(kObjEnd);
+		        auto obj_header_size = sm[0].length();
+
+		        id = sm[1];
+
+		        pdf_object = buffer + obj_start;
+		        object_size = obj_end-obj_start;
+		        auto next_item = pdf_object + obj_header_size;
+
+		        if (string_buffer.substr(obj_start + obj_header_size, kDictionaryBegin.size()) == "<<") { //It has a dictionary
+
+			        DictionaryBoundaries dict_boundaries = GetDictionaryBoundaries(pdf_object + obj_header_size,
+					        pdf_object + object_size);
+			        dictionary_start	= dict_boundaries.start;
+			        dictionary_end 		= dict_boundaries.end;
+
+			        UnfoldDictionary(&dictionary, dictionary_start, dictionary_end);
+
+			        GetFilters();
+			        GetStream();
+		        }
+	        }
+	        // There is no more 'obj'
+	        else {
+		        object_size = 0;
+		        pdf_object = buffer + size;
+	        }
+        }
+
+        PdfObject::~PdfObject() {
+	        delete[] decoded_stream;
+        }
+
+        std::string PdfObject::GetId() {
+	        return id;
+        }
+
+        Dictionary* PdfObject::GetDictionary() {
+	        return &dictionary;
+        }
+
+        void  PdfObject::UnfoldDictionary(Dictionary* dictionary, const uint8_t* begin, const uint8_t* end) {
+	        size_t dictionary_index{0};
+
+	        const std::string kKeyRegEx = "([[:w:]-]+)([[:s:]])*(.*)"; // reg_exp.g. '/Key'
+	        const std::string kObjRefRegEx = "^([0-9]+[[:space:]]+[0-9]+)([[:space:]]+R[[:space:]]*)(.*)"; // for indirect object reference '0 5 R'
+	        const std::string kArrayRegEx = "^(\\[.*\\])(.*)";													// for arrays '[zzz yyy]'
+	        const std::string kLiteralRegEx = "^(\\(.*\\))(.*)";													// for literals '(this is a literal)'
+
+
+	        const std::regex key_regex {kKeyRegEx};
+	        const std::regex obj_ref_regex {kObjRefRegEx};
+	        const std::regex array_regex {kArrayRegEx};
+	        const std::regex literal_regex{kLiteralRegEx};
+
+	        std::string last_part(begin, end);				//Dictionary splitted in key and rest
+	        std::string key{};								// Key of dictionary
+
+	        std::smatch sm;
+	        std::regex_search (last_part, sm, key_regex); // Searchs for the begining of an object, reg_exp.g. '10 0 obj'
+	        auto directory_elem = sm.size();
+
+	        while (directory_elem > 1) {
+		        #ifdef DEBUG
+		            std::cout << sm.size() << std::endl;
+		            std::cout << sm.str(0) << std::endl;
+		            std::cout << sm.str(1) << std::endl;
+		            std::cout << sm.str(directory_elem-1) << std::endl;
+		        #endif
+
+		        key = sm.str(1);
+		        last_part = sm.str(directory_elem-1);
+		        dictionary_index = dictionary_index + sm.position(directory_elem-1);
+
+		        // It is a key-dictionary pair
+		        if (last_part.substr(0, kDictionaryBegin.size()) == kDictionaryBegin) { // Contains a dictionary as value
+			        auto dict_bound = GetDictionaryBoundaries(begin + dictionary_index, end);
+			        Dictionary* new_dict = new Dictionary;
+			        UnfoldDictionary(new_dict, dict_bound.start, dict_bound.end);
+			        dictionary->dictionaries[key] = new_dict;
+
+			        dictionary_index = dictionary_index + dict_bound.end - dict_bound.start;
+			        last_part = last_part.substr(dict_bound.end - dict_bound.start, std::string::npos);
+		        } else { // It is a key-value pair
+			        std::smatch sm_key;
+			        std::smatch sm_array;
+			        std::smatch sm_literal;
+			        std::smatch sm_obj_ref;
+
+			        std::regex_search (last_part, sm_key, key_regex);
+			        std::regex_search (last_part, sm_array, array_regex);
+			        std::regex_search (last_part, sm_literal, literal_regex);
+			        std::regex_search (last_part, sm_obj_ref, obj_ref_regex);
+
+			        if (sm_obj_ref.size() > 0) {
+				        sm = sm_obj_ref;
+			        } else if (sm_array.size() > 0) {
+				        sm = sm_array;
+			        } else if (sm_literal.size() > 0) {
+				        sm = sm_literal;
+			        } else if (sm_key.size() > 0){
+				        sm = sm_key;
+			        }
+
+			        directory_elem = sm.size();
+
+			        dictionary->values[key] = sm.str(1);
+
+			        last_part = sm.str(directory_elem-1);
+			        dictionary_index = dictionary_index + sm.position(directory_elem-1);
+		        }
+
+		        std::regex_search (last_part, sm, key_regex);
+		        directory_elem = sm.size();
+	        }
+        }
+
+        void PdfObject::GetFilters() {
+	        const char kDelimiter {'/'};
+
+	        size_t filter_start = FindStringInBuffer (pdf_object, kFilterTagBegin.c_str(), object_size); //Begin of 'Filter' object
+
+	        if (filter_start != std::string::npos) {
+		        filter_start = filter_start + kFilterTagBegin.length();
+		        size_t filter_size = FindStringInBuffer (pdf_object + filter_start, kFilterTagEnd.c_str(), object_size - filter_start);
+
+		        if (filter_size != std::string::npos) {
+			        dictionary_end = pdf_object + filter_start + filter_size;
+
+			        std::string line{(char*)pdf_object, filter_start, filter_size};
+			        auto filters = SplitString(line, kDelimiter);
+
+			        for (size_t i = 0; i<filters.size(); i++) {
+				        if (kFilterDictionary.end() != std::find(kFilterDictionary.begin(), kFilterDictionary.end(), filters[i])) {
+					        this->filters.push_back(filters[i]);
+				        }
+			        }
+		        }
+	        } else {
+		        dictionary_end = pdf_object; // No filter found
+	        }
+        }
+
+        void PdfObject::GetStream() {
+
+	        size_t stream_position = FindStringInBuffer (dictionary_end, kStreamBegin.c_str(), object_size - (dictionary_end - pdf_object)); //Begin of 'stream'
+
+	        if (stream_position != std::string::npos) {
+		        stream_position = stream_position + kStreamBegin.length();
+		        auto stream_buffer = dictionary_end + stream_position;
+
+		        // To comply with 7.3.8.1 of ISO 32000:2008 and get exactly the start of stream to decode
+		        bool correct_syntax = false;
+		        if (memcmp (stream_buffer, kPdfEol1, 1) == 0) {
+			        stream_buffer++;
+			        correct_syntax = true;
+		        } else if (memcmp (stream_buffer, kPdfEol2, 2) == 0) {
+			        stream_buffer = stream_buffer+2;
+			        correct_syntax = true;
+		        }
+
+		        if (correct_syntax) {
+			        size_t stream_size = FindStringInBuffer (stream_buffer, kStreamEnd.c_str(), object_size - (stream_buffer - pdf_object));
+
+			        if (stream_size != std::string::npos) {
+				        // To comply with 7.3.8.1 of ISO 32000:2008 and get exactly the end of stream to decode
+				        correct_syntax = false;
+				        if (memcmp (stream_buffer + stream_size - 2, kPdfEol2, 2) == 0) {
+					        stream_size=stream_size-2;
+					        correct_syntax = true;
+				        } else if (memcmp (stream_buffer + stream_size - 1, kPdfEol1, 1) == 0){
+					        stream_size--;
+					        correct_syntax = true;
+				        }
+
+				        if (correct_syntax){
+					        stream_start = stream_buffer; // TODO Verify value
+					        this->stream_size = stream_size;
+					        stream_end = stream_start + stream_size;
+				        }
+			        }
+		        }
+	        }
+        }
+
+        bool PdfObject::HasStream(){
+            return (stream_size > 0);
+        }
+
+        bool PdfObject::ExtractStream(std::string filter){
+	        #ifdef DEBUG
+    	        std::cout << "applied filter:\n" << filter << std::endl; //Debug
+	        #endif
+
+	        if (filter == "") {
+		        std::vector<uint8_t> temp (stream_start, stream_end);
+		        decoded_stream_vector = temp;
+		        return true;
+	        } else if ((filter.compare("LZWDecode") != 0) || (filter.compare("FlateDecode") != 0)) {
+		        FlateLZWDecode();
+		        return true;
+	        } else {
+		        #ifdef DEBUG
+		        std::cout << "No accepted filter" << std::endl;
+		        #endif
+
+		        decoded_stream_vector = {};
+		        return false;
+	        }
+        }
+
+        void PdfObject::FlateLZWDecode() {
+	        #ifdef DEBUG
+    	        std::cout << "Deflating..." << std::endl; // Debug
+	        #endif
+
+	        size_t outsize = (stream_size)*DEFLATE_BUFFER_MULTIPLIER;
+	        decoded_stream = new uint8_t [outsize]{'\0'};
+
+	        //Now use zlib to inflate. Must be initialized to '\0'
+	        z_stream zstrm{};
+
+	        zstrm.avail_in = stream_size + 1;
+	        zstrm.avail_out = outsize;
+	        zstrm.next_in = (Bytef*)(stream_start);
+	        zstrm.next_out = (Bytef*)decoded_stream;
+
+	        #ifdef DEBUG
+    	        std::cout << "Deflating...2" << std::endl; // DEBUG
+	        #endif
+
+	        int rsti = inflateInit(&zstrm);
+
+	        #ifdef DEBUG
+    	        std::cout << "Deflating...3" << std::endl; // DEBUG
+	        #endif
+
+	        if (rsti == Z_OK) {
+		        #ifdef DEBUG
+    		        std::cout << "Z_OK" << std::endl;
+		        #endif
+
+		        int rst2 = inflate (&zstrm, Z_FINISH);
+
+		        #ifdef DEBUG
+		        std::cout << "rst2 = " << rsti << std::endl;
+		        #endif
+
+		        if (rst2 >= 0) {
+			        //Ok, got something, extract the content:
+			        decoded_stream_size = zstrm.total_out;
+
+			        decoded_stream_vector.assign(decoded_stream, decoded_stream+decoded_stream_size);
+			        #ifdef DEBUG
+			        std::cout << id <<" DECODED content:\n" << decoded_stream << std::endl; // DEBUG
+			        #endif
+		        }
+	        } else {
+		        std::cout << "Z_NOK" << std::endl;
+	        }
+        }
+
+        std::vector<uint8_t> PdfObject::GetDecodedStream(){
+	        return decoded_stream_vector;
+        }
+
+        /**
+         * Extract text from plain stream.
+         *
+         * Uses the decoded_stream as input and puts its result in parsed_text.
+         */
+        void PdfObject::TextParser() { //TODO unbalanced parentesis (escaped chars) and Hexadecimal strings
+	        bool in_text_block = false;		// Indicates when the position is inside a BT/ET block
+	        size_t parenthesis_depth = 0;	// Indicates when the position is inside a block delimited by '(' and ')' (a literal) and its depth
+	        bool escaped_char = false;		// Indicates when the following character is escaped
+
+	        uint8_t buffer[EXTRACT_TEXT_BUFFER_SIZE]{'\0'};
+	        std::string octal_char{};
+
+	        for (size_t i=0; i < decoded_stream_size; i++) {
+		        uint8_t current_char = decoded_stream[i];
+
+		        // Rotate the buffer and stores the previous characters to detect BT and ET
+		        buffer[0] = buffer[1];
+		        buffer[1] = current_char;
+
+		        // If not in BT/ET check if it is a start of BT/ET (000)->(100) [in_text_block, parentesis_depth, escaped]
+		        if (!in_text_block && (memcmp(buffer, TEXT_BLOCK_START, 2) == 0)) {
+			        in_text_block = true;
+                } else if (in_text_block) {
+			        if (parenthesis_depth == 0) {
+				        // Start of literal '(' (100)->(110)
+				        if (current_char == '(') {
+					        parenthesis_depth++;
+				        } else if (memcmp(buffer, TEXT_BLOCK_END, 2) == 0) { // End of BT/ET (100)->(000)
+					        in_text_block = false;
+				        }
+			        } else if (parenthesis_depth > 0) { // Already inside a literal (110) or (111)
+				        if (escaped_char && octal_char.empty()) {
+					        if (isdigit(current_char)) {
+						        octal_char.push_back(current_char);
+					        } else {
+						        escaped_char = false;
+
+						        if (current_char == 'n') {
+							        parsed_text.push_back('\n');}
+
+						        else if (current_char == 'r') {
+							        parsed_text.push_back('\r');}
+
+						        else if (current_char == 't') {
+							        parsed_text.push_back('\t');}
+
+						        else if (current_char == 'b'){
+							        parsed_text.push_back('\b');}
+
+						        else if (current_char == 'f'){
+							        parsed_text.push_back('\f');}
+
+						        else if (current_char == '\\'){
+							        parsed_text.push_back('\\');}
+
+						        else if (current_char == '('){
+							        parsed_text.push_back('(');}
+
+						        else if (current_char == ')'){
+							        parsed_text.push_back(')');}
+					        }
+				        } else {
+					        // Escaped and octal
+					        if (!octal_char.empty()) {
+						        if (octal_char.size() == 3 || !isdigit(current_char)) {
+							        escaped_char = false;
+							        uint8_t actual_char = static_cast<uint8_t>(std::stoi(octal_char));
+							        parsed_text.push_back(actual_char);
+							        octal_char.erase();
+						        } else {
+							        octal_char.push_back(current_char);
+						        }
+					        }
+
+					        // Not escaped
+					        if (!escaped_char) {
+						        if (current_char == '\\') {
+							        escaped_char = true;
+						        } else {
+							        if (current_char == '(') {
+								        parenthesis_depth++;
+							        } else if (current_char == ')') {
+								        parenthesis_depth--;
+							        }
+
+							        if (parenthesis_depth > 0) {
+								        parsed_text.push_back(current_char);
+							        }
+						        }
+					        }
+				        }
+			        }
+		        }
+	        }
+
+	        #ifdef DEBUG
+	            std::string output(parsed_text.begin(), parsed_text.end()); // DEBUG
+	            std::cout << "output:\n" << output << std::endl << std::flush; // DEBUG
+	        #endif
+        }
+
+        //start of 'obj' + size of 'obj' + length of flag
+        const uint8_t* PdfObject::GetObjectEnd() {
+	        if (object_size == 0) {
+		        return pdf_object;
+	        } else {
+		        return pdf_object + object_size + kObjEnd.length();
+	        }
+        }
+
+        /**
+         * @brief	Detects the limits of the outer dictionary between the limits provided
+         * @param begin
+         * @param end
+         */
+        DictionaryBoundaries PdfObject::GetDictionaryBoundaries (const uint8_t* begin, const uint8_t* end) {
+	        std::string string_buffer(begin, end);
+
+	        auto dict_begin = string_buffer.find(kDictionaryBegin);
+	        DictionaryBoundaries dict_bound{};
+	        dict_bound.start =  begin + dict_begin;
+
+	        size_t last_dictionary_position{dict_begin+kDictionaryBegin.size()};	// Two chars '<<' as the first dictionary begin
+	        size_t dictionaries_counter{1};								// It has at least 1 dictionary
+	        auto dictionaries_quantity = dictionaries_counter;			// Dictionary blocks present
+	        auto dictionary_size = end - begin;							// Not necessarily the dictionary itself, but a limit to search
+
+	        while ((last_dictionary_position < dictionary_size) && (dictionaries_counter > 0)) {
+		        if (string_buffer.substr(dict_begin + last_dictionary_position, kDictionaryBegin.size()) == kDictionaryBegin) {
+			        last_dictionary_position = last_dictionary_position + 2;
+			        ++dictionaries_counter;
+			        ++dictionaries_quantity;
+		        } else if (string_buffer.substr(dict_begin + last_dictionary_position, kDictionaryEnd.size()) == kDictionaryEnd) {
+			        last_dictionary_position = last_dictionary_position + 2;
+			        --dictionaries_counter;
+		        } else {
+			        ++last_dictionary_position;
+		        }
+	        }
+	        dict_bound.end = begin + last_dictionary_position;
+
+	        return dict_bound;
+        }
+
+    } // !extern "C"
+
+} // !namespace pdfparser

--- a/libs/pdf_object.cpp
+++ b/libs/pdf_object.cpp
@@ -1,8 +1,31 @@
-/*
+/*****************************************************************************
  *
- *  Created on: Nov 29, 2017
- *      Author: rodrigo
- */
+ * YEXTEND: Help for YARA users.
+ * This file is part of yextend.
+ *
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
 
 /* Include order
 Own .h.
@@ -312,7 +335,7 @@ void PdfObject::GetFilters() {
 void PdfObject::GetStream(){
 
 	size_t stream_position = FindStringInBuffer (dictionary_end, kStreamBegin.c_str(), object_size - (dictionary_end - pdf_object)); //Begin of 'stream'
-	
+
 	if (stream_position != std::string::npos){
 		stream_position = stream_position + kStreamBegin.length();
 		auto stream_buffer = dictionary_end + stream_position;
@@ -918,4 +941,3 @@ std::string Dictionary::IndirectReference() {
 } // !extern "C"
 
 } // !namespace pdfparser
-

--- a/libs/pdf_object.cpp
+++ b/libs/pdf_object.cpp
@@ -99,7 +99,7 @@ PdfObject::PdfObject(const uint8_t* buffer, size_t size){
 
 		pdf_object = buffer + obj_start;
 		object_size = obj_end-obj_start;
-		auto next_item = pdf_object + obj_header_size;
+		//auto next_item = pdf_object + obj_header_size;
 
 		if (string_buffer.substr(obj_start + obj_header_size, kDictionaryBegin.size()) == "<<") { //It has a dictionary
 
@@ -122,7 +122,7 @@ PdfObject::PdfObject(const uint8_t* buffer, size_t size){
 
 
 PdfObject::~PdfObject(){
-	delete[] decoded_stream;
+	//delete[] decoded_stream;
 //	if (dictionary.dictionaries.size() > 0)
 //		DeleteDictionary(&dictionary);
 }
@@ -157,7 +157,7 @@ void  PdfObject::UnfoldDictionary(Dictionary* dictionary, const uint8_t* begin, 
 	//const std::string kObjectBegin = R("^([0-9]+\s+[0-9]+\s+obj)(\s*)([\s\S]*))"; // Obj '15 0 obj'
 	//const std::string kNameRegEx 	= R"(^(/[^\x00-\x20\(\)\<\>\[\]\{\}/\%\x7f-\xff]+)(\s*)([\s\S]*))";	// Name objects /Key1+3 Optimal TODO
 	const std::string kBoolRegEx	= R"(^(true|false)\s*([\s\S]*))";				// Boolean true or false
-	const std::string kNameRegEx 	= R"(^(/[[:w:]\+\-]+)\s*([\s\S]*))";			// Name objects /Key1+3
+	const std::string kNameRegEx 	= R"(^[\s]*(/[[:w:]\+\-]+)\s*([\s\S]*))";			// Name objects /Key1+3
 	const std::string kObjRefRegEx 	= R"(^([0-9]+\s+[0-9]+)\s+R\s*([\s\S]*))";		// Indirect object reference '0 5 R'
 	// V0 const std::string kArrayRegEx 	= R"(^(\[.*\])([\s\S]*))";				// Arrays '[zzz yyy]'
 	const std::string kArrayRegEx 	= R"(^(\[[[:alnum:]\+\-/\R\s]+\])\s*([\s\S]*))";// Arrays '[zzz yyy]'
@@ -335,7 +335,7 @@ void PdfObject::GetFilters() {
 void PdfObject::GetStream(){
 
 	size_t stream_position = FindStringInBuffer (dictionary_end, kStreamBegin.c_str(), object_size - (dictionary_end - pdf_object)); //Begin of 'stream'
-
+	
 	if (stream_position != std::string::npos){
 		stream_position = stream_position + kStreamBegin.length();
 		auto stream_buffer = dictionary_end + stream_position;
@@ -417,7 +417,7 @@ void PdfObject::FlateLZWDecode() {
 #endif
 
 	size_t outsize = (stream_size)*DEFLATE_BUFFER_MULTIPLIER;
-	decoded_stream = new uint8_t [outsize]{'\0'};
+	auto decoded_stream = new uint8_t [outsize]{'\0'};
 
 	//Now use zlib to inflate. Must be initialized to '\0'
 	z_stream zstrm{};
@@ -436,7 +436,7 @@ void PdfObject::FlateLZWDecode() {
 		if (rst2 >= 0)
 		{
 			//Ok, got something, extract the content:
-			decoded_stream_size = zstrm.total_out;
+			auto decoded_stream_size = zstrm.total_out;
 			decoded_stream_vector.assign(decoded_stream, decoded_stream+decoded_stream_size);
 
 #ifdef DEBUG
@@ -449,6 +449,8 @@ void PdfObject::FlateLZWDecode() {
 		std::cout << "Z_NOK" << std::endl;
 #endif
 	}
+
+	delete[] decoded_stream;
 }
 
 
@@ -460,7 +462,7 @@ std::vector<uint8_t> PdfObject::GetDecodedStream(){
 /**
  * Extract text from plain stream.
  *
- * Uses the decoded_stream as input and puts its result in parsed_plain_text.
+ * Uses the decoded_stream_vector as input and puts its result in parsed_plain_text.
  */
 //TODO Hexadecimal strings
 void PdfObject::ParseText(std::map<std::string, Font>& fonts){
@@ -470,7 +472,6 @@ void PdfObject::ParseText(std::map<std::string, Font>& fonts){
 	size_t square_brackets_depth = 0;	// Indicates when the position is inside a array. It shall be printed with TJ
 	bool escaped_char = false;			// Indicates when the following character is escaped
 
-	uint8_t current_char{'\0'};
 	uint8_t buffer[EXTRACT_TEXT_BUFFER_SIZE]{'\0'};
 
 	std::string octal_char{};
@@ -478,8 +479,8 @@ void PdfObject::ParseText(std::map<std::string, Font>& fonts){
 	std::string local_font{};	// Local font in BT/ET
 
 	size_t decoded_stream_idx=0;
-	while (decoded_stream_idx < decoded_stream_size) {
-		current_char = decoded_stream[decoded_stream_idx++];
+	while (decoded_stream_idx < decoded_stream_vector.size()) {
+		auto current_char = decoded_stream_vector[decoded_stream_idx++];
 
 		// Rotate the buffer and stores the previous characters to detect BT and ET
 		for (unsigned char j=0; j<EXTRACT_TEXT_BUFFER_SIZE-1; ++j) {
@@ -501,7 +502,8 @@ void PdfObject::ParseText(std::map<std::string, Font>& fonts){
 				if (memcmp(buffer, TEXT_FONT, 2) == 0){
 					local_font = TEXT_FONT;
 
-					auto from = reinterpret_cast<const char *>(&decoded_stream[decoded_stream_idx]);
+					//auto from = reinterpret_cast<const char *>(&decoded_stream_vector[decoded_stream_idx]);
+					auto from = decoded_stream_vector.begin() + decoded_stream_idx;
 					auto to = from + TEXT_FONT_MAX_SIZE;
 
 					std::string font_buffer(from, to);
@@ -709,7 +711,7 @@ std::string PdfObject::ExtractFontDefinition(Dictionary* dictionary) {
 		font_definition = dictionary->values[kFontTagBegin];
 		}
 
-	// If not and there are dictionaries check them
+	// If not and there are dictionaries check inside them
 	else if (dictionary->dictionaries.size() != 0) {
 		auto subdictionary = dictionary->dictionaries; //map
 
@@ -941,3 +943,4 @@ std::string Dictionary::IndirectReference() {
 } // !extern "C"
 
 } // !namespace pdfparser
+

--- a/libs/pdf_object.h
+++ b/libs/pdf_object.h
@@ -30,6 +30,13 @@
 #ifndef OBJECT_H_
 #define OBJECT_H_
 
+/* Include order
+Own .h.
+C.
+C++.
+Other libraries' .h files.
+Your project's .h files.
+*/
 #include <stdint.h>
 
 #include <cstddef>
@@ -91,12 +98,12 @@ const std::vector<std::string> kTextDictionary{ // BS-25. Dismiss no text stream
 	"/Contents"
 	};
 
-const std::vector<std::string> kNonTextDictionary{ // BS-25. Dismiss no text stream objects (/Length1)
+const std::vector<std::string> kNonTextDictionaryKeys{ // BS-25. Dismiss no text stream objects (/Length1)
 	"/Length1",
 	"/Length2",
 	"/Length3",
 	"/DL",
-	"/EmbeddedFile"
+	"/EmbeddedFile" // This is not a /key, it is a value
 	};
 
 const std::vector<std::string> kNonTextAttributes{ // BS-25. Dismiss no text stream objects (/Length1)
@@ -164,12 +171,10 @@ class PdfObject {
 	const uint8_t*	stream_end{nullptr};		// Pointer to the end of stream part in uint8_t*
 	size_t			stream_size{0};
 
-	std::vector<uint8_t> decoded_stream_vector{}; // Stream after decode (eg. FlatDecode)
-	uint8_t*			decoded_stream{nullptr};
-	size_t				decoded_stream_size{0};
-	size_t				text_size{0};
-	std::vector<uint8_t> parsed_plain_text{};		// BOM for Little Endian {0xff, 0xfe}. Not needed if endianess is specified en conversion;
-	std::string			parsed_plain_text_utf8{};
+	std::vector<uint8_t> 	decoded_stream_vector{}; // Stream after decode (eg. FlateDecode)
+	size_t					text_size{0};
+	std::vector<uint8_t>	parsed_plain_text{};		// BOM for Little Endian {0xff, 0xfe}. Not needed if endianess is specified en conversion;
+	std::string				parsed_plain_text_utf8{};
 
 	std::vector<uint8_t> file{};				// extracted file
 

--- a/libs/pdf_object.h
+++ b/libs/pdf_object.h
@@ -30,7 +30,7 @@
 #ifndef PDF_OBJECT_H_
 #define PDF_OBJECT_H_
 
-#define DEBUG
+//#define DEBUG
 
 #include <stdint.h>
 

--- a/libs/pdf_object.h
+++ b/libs/pdf_object.h
@@ -1,36 +1,12 @@
-/*****************************************************************************
+/*
+ * parser.h
  *
- * YEXTEND: Help for YARA users.
- * This file is part of yextend.
- *
- * Copyright (c) 2014-2018, Bayshore Networks, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- * the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- * following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
+ *  Created on: Nov 29, 2017
+ *      Author: rodrigo
+ */
 
-#ifndef PDF_OBJECT_H_
-#define PDF_OBJECT_H_
-
-//#define DEBUG
+#ifndef OBJECT_H_
+#define OBJECT_H_
 
 #include <stdint.h>
 
@@ -40,132 +16,187 @@
 #include <unordered_map>
 #include <vector>
 
+#include "pdf_font.h"
+#include "pdf_text_encoding.h"
+
+
 namespace pdfparser {
 
-    extern "C" {
+extern "C" {
 
-        #define DEFLATE_BUFFER_MULTIPLIER		10
-        #define EXTRACT_TEXT_BUFFER_SIZE		2
-        #define TEXT_BLOCK_START				"BT"
-        #define TEXT_BLOCK_END					"ET"
+#define DEFLATE_BUFFER_MULTIPLIER		10
+#define EXTRACT_TEXT_BUFFER_SIZE		2  //2 needed for BT and ET
+//#define EXTRACT_TEXT_OCTAL_BUFFER_SIZE	3
+#define TEXT_BLOCK_START				"BT"
+#define TEXT_BLOCK_END					"ET"
+#define TEXT_FONT						"/F"
+#define TEXT_FONT_MAX_SIZE				4	// including "/F"
+#define TEXT_PRINT_ARRAY				"TJ" // Command in BT/ET block to print array []
+#define TEXT_PRINT_LITERAL				"Tj" // Command in BT/ET block to print literal (). Also ' and " TODO
 
-        struct Dictionary {
-	        std::unordered_map<std::string, std::string> values;
-	        std::unordered_map<std::string, Dictionary*> dictionaries;
-        };
+const std::string kDictionaryBegin	{"<<"};
+const std::string kDictionaryEnd	{">>"};
 
-        struct DictionaryBoundaries {
-	        const uint8_t* start{nullptr};
-	        const uint8_t* end{nullptr};
-        };
+const std::string kToUnicode		{"/ToUnicode"};
+const std::string kFilterTagBegin	{"/Filter"}; // Flag of begin of 'Filter' section
 
-        const std::vector<std::string> kFilterDictionary {
-	        "ASCIIHexDecode",
-	        "ASCII85Decode",
-	        "LZWDecode",
-	        "FlateDecode",
-	        "RunLenghtDecode",
-	        "CCITTFaxDecode",
-	        "JBIG2Decode",
-	        "DCTDecode",
-	        "JPXDecode",
-	        "Crypt"
-        };
+struct Dictionary {
+	std::unordered_map<std::string, std::string> values; // Stores the key-value pairs of a certain dictionary
+	std::unordered_map<std::string, Dictionary*> dictionaries; // Stores the key-dictionary pairs of a certain dictionary
 
-        const std::vector<std::string> kTextDictionary { // BS-25. Dismiss no text stream objects (/Length1)
-	        "Contents"
-	    };
+	std::string IndirectReference();
+};
 
-        const std::vector<std::string> kNonTextDictionary { // BS-25. Dismiss no text stream objects (/Length1)
-	        "Length1",
-	        "Length2",
-	        "Length3",
-	        "DL",
-	        "EmbeddedFile"
-	    };
+struct DictionaryBoundaries {
+	const uint8_t* start{nullptr};
+	const uint8_t* end{nullptr};
+};
 
-        const std::vector<std::string> kNonTextAttributes { // BS-25. Dismiss no text stream objects (/Length1)
-	        "ToUnicode",
-	        "FontFile2"
-	    };
 
-        const std::vector<std::string> kFileFlag { // BS-26. Detach from PDF attachments specified as files.
-	        "DL",
-	        "EmbeddedFile"
-	    };
+const std::vector<std::string> kFilterDictionary{
+	"/ASCIIHexDecode",
+	"/ASCII85Decode",
+	"/LZWDecode",
+	"/FlateDecode",
+	"/RunLenghtDecode",
+	"/CCITTFaxDecode",
+	"/JBIG2Decode",
+	"/DCTDecode",
+	"/JPXDecode",
+	"/Crypt"};
 
-        const std::vector<std::string> kNonFileAttributes { // BS-26. Detach from PDF attachments specified as files.
-	        "Contents"
-	    };
+const std::vector<std::string> kTextDictionary{ // BS-25. Dismiss no text stream objects (/Length1)
+	"/Contents"
+	};
 
-        const std::vector<std::string> kNonFileDictionary { // BS-26. Detach from PDF attachments specified as files.
-	        "ObjStm",
-	        "XObject",
-	        "XML",
-	        "Xref"
-        };
+const std::vector<std::string> kNonTextDictionary{ // BS-25. Dismiss no text stream objects (/Length1)
+	"/Length1",
+	"/Length2",
+	"/Length3",
+	"/DL",
+	"/EmbeddedFile"
+	};
 
-        class PdfObject {
-	        const std::string kObjBegin			{"obj"};	// Flag to start of 'obj' section
-	        const std::string kObjEnd			{"endobj"}; // Flag of end of 'obj' section
+const std::vector<std::string> kNonTextAttributes{ // BS-25. Dismiss no text stream objects (/Length1)
+	"/ToUnicode",
+	"/FontFile2"
+	};
 
-	        const std::string kFilterTagBegin	{"/Filter"}; // Flag of begin of 'Filter' section
-	        const std::string kFilterTagEnd		{">>"};
-	        const std::string kDictionaryBegin	{"<<"};
-	        const std::string kDictionaryEnd	{">>"};
+const std::vector<std::string> kFileAcceptedKeys{ // BS-26. Detach from PDF attachments specified as files.
+	"/DL",
+	"/EmbeddedFile"
+	};
 
-	        const std::string kStreamBegin		{"stream"}; // Flag of begin of 'stream' section
-	        const std::string kStreamEnd		{"endstream"}; // Flag of end of 'stream' section
+const std::vector<std::string> kNonFileAttributes{ // BS-26. Detach from PDF attachments specified as files.
+	"/Contents",
+	"/ToUnicode",
+	"/FontFile2"
+	};
 
-	        const char* kPdfEol1 = "\n";
-	        const char* kPdfEol2 = "\r\n";
+const std::vector<std::string> kNonFileDictionary{ // BS-26. Detach from PDF attachments specified as files.
+	"/ObjStm",
+	"/XObject",
+	"/XML",
+	"/XRef"
+	};
 
-	        std::string id{};
-	        Dictionary dictionary;
+// These operators inside a BT/ET block shall reset the array and literal buffers
+// i.e., the information in those buffers are related to these operators and have not
+// be considered as text
+const std::vector<std::string> kTextResetingOperators {
+	"Tc", "Tw", "Tz", "TL", "Tf", "Tr", "Ts", 	// Text state operators
+	"Td", "TD", "Tm", "T*"						// Text positioning operators
+	};
 
-	        //TODO Use structs instead of isolated members
-	        const uint8_t*	pdf_object{nullptr};		// Pointer to the start of 'obj' object
-	        size_t			object_size{0};				// The size of 'obj' object
 
-	        const uint8_t* dictionary_start{nullptr};
-	        const uint8_t* dictionary_end{nullptr};
+class PdfObject {
+	const std::string kObjBegin			{"obj"};	// Flag to start of 'obj' section
+	const std::string kObjEnd			{"endobj"}; // Flag of end of 'obj' section
 
-	        const uint8_t*	stream_start{nullptr};			// Pointer to the start of stream part in uint8_t*
-	        const uint8_t*	stream_end{nullptr};			// Pointer to the end of stream part in uint8_t*
-	        size_t			stream_size{0};
+	const std::string kNameTagBegin		{"/"};
 
-	        std::vector<uint8_t> decoded_stream_vector{};
-	        uint8_t*			decoded_stream{nullptr};
-	        size_t				decoded_stream_size{0};
-	        size_t				text_size{0};
-	        std::vector<uint8_t> parsed_text{};
+	const std::string kFilterTagEnd		{">>"};
 
-	        std::vector<uint8_t> file{};				// extracted file
+	const std::string kArrayTagBegin	{"["};
 
-	        std::vector<std::string> filters{};
+	const std::string kStreamBegin		{"stream"}; // Flag of begin of 'stream' section
+	const std::string kStreamEnd		{"endstream"}; // Flag of end of 'stream' section
 
-	        void GetFilters();
-	        void GetStream();
-	        void FlateLZWDecode();
-	        void UnfoldDictionary(Dictionary* dictionary, const uint8_t* begin, const uint8_t* end);
-	        DictionaryBoundaries GetDictionaryBoundaries (const uint8_t* begin, const uint8_t* end);
+	const std::string kFontTagBegin		{"/Font"}; // Indicates the font definition begin
 
-        public:
-	        PdfObject(const uint8_t* buffer, size_t size);
-	        ~PdfObject();
+	const char* kPdfEol1 = "\n";
+	const char* kPdfEol2 = "\r\n";
 
-	        std::string GetId();
-	        Dictionary* GetDictionary();
-	        bool ExtractStream(std::string filter);
-	        std::vector<uint8_t> GetDecodedStream();
-	        void TextParser();
-        	std::vector<uint8_t> GetParsedText();
-	        const uint8_t* GetObjectEnd();
-	        bool HasStream();
-        };
 
-    } // !extern "C"
+	std::string id{};
+	Dictionary dictionary{};
+
+	//TODO Use structs instead of isolated members
+	const uint8_t*	pdf_object{nullptr};		// Pointer to the start of 'obj' object
+	size_t			object_size{0};				// The size of 'obj' object
+
+	const uint8_t* dictionary_start{nullptr};	// Root dictionary
+	const uint8_t* dictionary_end{nullptr};		// Root dictionary
+
+	const uint8_t*	stream_start{nullptr};		// Pointer to the start of stream part in uint8_t*
+	const uint8_t*	stream_end{nullptr};		// Pointer to the end of stream part in uint8_t*
+	size_t			stream_size{0};
+
+	std::vector<uint8_t> decoded_stream_vector{}; // Stream after decode (eg. FlatDecode)
+	uint8_t*			decoded_stream{nullptr};
+	size_t				decoded_stream_size{0};
+	size_t				text_size{0};
+	std::vector<uint8_t> parsed_plain_text{};		// BOM for Little Endian {0xff, 0xfe}. Not needed if endianess is specified en conversion;
+	std::string			parsed_plain_text_utf8{};
+
+	std::vector<uint8_t> file{};				// extracted file
+
+	std::vector<std::string> filters{};
+
+
+	void GetFilters();
+	void GetStream();
+	void ParseTextArray(std::string& array, Font& font);
+	std::string ParseTextLiteral(std::string& text);
+	void FlateLZWDecode();
+	DictionaryBoundaries GetDictionaryBoundaries (const uint8_t* begin, const uint8_t* end);
+
+public:
+	PdfObject(const uint8_t* buffer, size_t size);
+	PdfObject();
+	~PdfObject();
+
+	std::string GetId();
+	Dictionary* GetDictionary();
+	bool ExtractStream(std::string filter);
+
+	/**
+	 * @brief	Examines the dictionary of the object looking for /Font definition and return it if it exist
+	 * @example Returns "65 0" doing reference to 65 0 R where Font is stored or "/F1 5 0 R" in the case font definition embedded
+	 * @param pointer to a dictionary struct
+	 * @return string containing /Font definition reference information. Empty string otherwise
+	 */
+	std::string ExtractFontDefinition(Dictionary* dictionary);
+
+	void UnfoldDictionary(Dictionary* dictionary, const uint8_t* begin, const uint8_t* end);
+
+	std::vector<uint8_t> GetDecodedStream();
+
+	/**
+	 * @brief Once stream is decoded, it parses the contained text inside BT/ET blocks applying fonts
+	 * @param fonts Maps of fonts to translate chars from CID to Unicode when necessary
+	 */
+	void ParseText(std::map<std::string, Font>& fonts);
+
+	std::vector<uint8_t> GetParsedPlainText(TextEncoding encoding);
+	const uint8_t* GetObjectEnd();
+	bool HasStream();
+};
+
+
+} // !extern "C"
 
 } // !namespace pdfparser
 
-#endif /* PDF_OBJECT_H_ */
+
+#endif /* OBJECT_H_ */

--- a/libs/pdf_object.h
+++ b/libs/pdf_object.h
@@ -1,0 +1,170 @@
+/*****************************************************************************
+ *
+ * YEXTEND: Help for YARA users.
+ * This file is part of yextend.
+ *
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+
+#ifndef PDF_OBJECT_H_
+#define PDF_OBJECT_H_
+
+#define DEBUG
+
+#include <stdint.h>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace pdfparser {
+
+    extern "C" {
+
+        #define DEFLATE_BUFFER_MULTIPLIER		10
+        #define EXTRACT_TEXT_BUFFER_SIZE		2
+        #define TEXT_BLOCK_START				"BT"
+        #define TEXT_BLOCK_END					"ET"
+
+        struct Dictionary {
+	        std::unordered_map<std::string, std::string> values;
+	        std::unordered_map<std::string, Dictionary*> dictionaries;
+        };
+
+        struct DictionaryBoundaries {
+	        const uint8_t* start{nullptr};
+	        const uint8_t* end{nullptr};
+        };
+
+        const std::vector<std::string> kFilterDictionary {
+	        "ASCIIHexDecode",
+	        "ASCII85Decode",
+	        "LZWDecode",
+	        "FlateDecode",
+	        "RunLenghtDecode",
+	        "CCITTFaxDecode",
+	        "JBIG2Decode",
+	        "DCTDecode",
+	        "JPXDecode",
+	        "Crypt"
+        };
+
+        const std::vector<std::string> kTextDictionary { // BS-25. Dismiss no text stream objects (/Length1)
+	        "Contents"
+	    };
+
+        const std::vector<std::string> kNonTextDictionary { // BS-25. Dismiss no text stream objects (/Length1)
+	        "Length1",
+	        "Length2",
+	        "Length3",
+	        "DL",
+	        "EmbeddedFile"
+	    };
+
+        const std::vector<std::string> kNonTextAttributes { // BS-25. Dismiss no text stream objects (/Length1)
+	        "ToUnicode",
+	        "FontFile2"
+	    };
+
+        const std::vector<std::string> kFileFlag { // BS-26. Detach from PDF attachments specified as files.
+	        "DL",
+	        "EmbeddedFile"
+	    };
+
+        const std::vector<std::string> kNonFileAttributes { // BS-26. Detach from PDF attachments specified as files.
+	        "Contents"
+	    };
+
+        const std::vector<std::string> kNonFileDictionary { // BS-26. Detach from PDF attachments specified as files.
+	        "ObjStm",
+	        "XObject",
+	        "XML",
+	        "Xref"
+        };
+
+        class PdfObject {
+	        const std::string kObjBegin			{"obj"};	// Flag to start of 'obj' section
+	        const std::string kObjEnd			{"endobj"}; // Flag of end of 'obj' section
+
+	        const std::string kFilterTagBegin	{"/Filter"}; // Flag of begin of 'Filter' section
+	        const std::string kFilterTagEnd		{">>"};
+	        const std::string kDictionaryBegin	{"<<"};
+	        const std::string kDictionaryEnd	{">>"};
+
+	        const std::string kStreamBegin		{"stream"}; // Flag of begin of 'stream' section
+	        const std::string kStreamEnd		{"endstream"}; // Flag of end of 'stream' section
+
+	        const char* kPdfEol1 = "\n";
+	        const char* kPdfEol2 = "\r\n";
+
+	        std::string id{};
+	        Dictionary dictionary;
+
+	        //TODO Use structs instead of isolated members
+	        const uint8_t*	pdf_object{nullptr};		// Pointer to the start of 'obj' object
+	        size_t			object_size{0};				// The size of 'obj' object
+
+	        const uint8_t* dictionary_start{nullptr};
+	        const uint8_t* dictionary_end{nullptr};
+
+	        const uint8_t*	stream_start{nullptr};			// Pointer to the start of stream part in uint8_t*
+	        const uint8_t*	stream_end{nullptr};			// Pointer to the end of stream part in uint8_t*
+	        size_t			stream_size{0};
+
+	        std::vector<uint8_t> decoded_stream_vector{};
+	        uint8_t*			decoded_stream{nullptr};
+	        size_t				decoded_stream_size{0};
+	        size_t				text_size{0};
+	        std::vector<uint8_t> parsed_text{};
+
+	        std::vector<uint8_t> file{};				// extracted file
+
+	        std::vector<std::string> filters{};
+
+	        void GetFilters();
+	        void GetStream();
+	        void FlateLZWDecode();
+	        void UnfoldDictionary(Dictionary* dictionary, const uint8_t* begin, const uint8_t* end);
+	        DictionaryBoundaries GetDictionaryBoundaries (const uint8_t* begin, const uint8_t* end);
+
+        public:
+	        PdfObject(const uint8_t* buffer, size_t size);
+	        ~PdfObject();
+
+	        std::string GetId();
+	        Dictionary* GetDictionary();
+	        bool ExtractStream(std::string filter);
+	        std::vector<uint8_t> GetDecodedStream();
+	        void TextParser();
+	        const uint8_t* GetObjectEnd();
+	        bool HasStream();
+        };
+
+    } // !extern "C"
+
+} // !namespace pdfparser
+
+#endif /* PDF_OBJECT_H_ */

--- a/libs/pdf_object.h
+++ b/libs/pdf_object.h
@@ -1,9 +1,31 @@
-/*
- * parser.h
+/*****************************************************************************
  *
- *  Created on: Nov 29, 2017
- *      Author: rodrigo
- */
+ * YEXTEND: Help for YARA users.
+ * This file is part of yextend.
+ *
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
 
 #ifndef OBJECT_H_
 #define OBJECT_H_

--- a/libs/pdf_object.h
+++ b/libs/pdf_object.h
@@ -159,6 +159,7 @@ namespace pdfparser {
 	        bool ExtractStream(std::string filter);
 	        std::vector<uint8_t> GetDecodedStream();
 	        void TextParser();
+        	std::vector<uint8_t> GetParsedText();
 	        const uint8_t* GetObjectEnd();
 	        bool HasStream();
         };

--- a/libs/pdf_parser.cpp
+++ b/libs/pdf_parser.cpp
@@ -3,21 +3,21 @@
  * YEXTEND: Help for YARA users.
  * This file is part of yextend.
  *
- * Copyright (c) 2014-2017, Bayshore Networks, Inc.
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
  * following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
  * following disclaimer in the documentation and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
  * products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
@@ -27,143 +27,35 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
 
-#include "pdf_parser.h"
-#include <iostream>
-#include <stdio.h>
-#include <stdlib.h>
-#include <syslog.h>
-#include <exception>
-#include <uuid/uuid.h>
-#include <fstream>
-#include <string>
+#include "pdf_parser_helper.h"
+#include "pdf.h"
 
-static const char *tmp_path = "/tmp/";
-static const char *pdf_to_text = "pdftotext";
-static const char *pdf_detach = "pdfdetach";
+extern "C" {
 
-static std::string get_stdout_cmd(std::string lcmd)
-{
+    namespace pdfparser {
 
-	std::string data;
-	FILE *stream;
-	const int max_buffer = 1024;
-	char buffer[max_buffer];
-	lcmd.append(" 2>&1");
+        /**
+         *
+         * @param pdf_pointer pointer where the pdf is loaded
+         * @param pdf_size size of pdf
+         * @return vector with decoded text. Text blocks are separated by \n. User should copy the decoded text.
+         */
+        std::vector<uint8_t> PdfToText (const uint8_t* pdf_pointer, size_t pdf_size) {
+	        Pdf pdf{pdf_pointer, pdf_size};
 
-	stream = popen(lcmd.c_str(), "r");
-	if (stream) {
-		while (!feof(stream))
-			if (fgets(buffer, max_buffer, stream) != NULL)
-				data.append(buffer);
-		pclose(stream);
-	}
-	return data;
-}
+	        std::vector<uint8_t> text_buffer = pdf.ExtractText();
 
-PDFParser::PDFParser(const uint8_t *buffer, size_t buffer_length)
-{
-    
-    uuid_t id;
-    char uuid_inp[40];
-    char uuid_out[40];
-    char input_filepath[1024];
-    char output_filepath[1024];
-    
-    //////////////////////////////////////////////////////////
-    uuid_generate(id);
-    uuid_unparse(id, uuid_inp);
-    snprintf(input_filepath, sizeof(input_filepath), "%s%s", tmp_path, uuid_inp);
-    // write original buffer to file
-    if (buffer && buffer_length) {
-        //TODO: Move code out of ctor() into init() method
-        std::ofstream fp;
-        fp.open(input_filepath, std::ios::out | std::ios::binary );
-        fp.write((char*)buffer, buffer_length);
-        fp.close();
-    }
+	        return text_buffer;
+        }
 
-    //////////////////////////////////////////////////////////
-    uuid_generate(id);
-    uuid_unparse(id, uuid_out);
-    snprintf(output_filepath, sizeof(output_filepath), "%s%s", tmp_path, uuid_out);
-    
-	// set class variables
-	stored_file_name = std::string(input_filepath, strlen(input_filepath));
-	buf_len = buffer_length;
-	extracted_file_name = std::string(output_filepath, strlen(output_filepath));
-}
+        std::vector<std::vector<uint8_t>> PdfDetach (const uint8_t* pdf_pointer, size_t pdf_size) {
+	        Pdf pdf{pdf_pointer, pdf_size};
 
-PDFParser::~PDFParser()
-{
-	// should we shred here instead?
-	if (remove(stored_file_name.c_str()) != 0) {
-		std::cout << "Error removing file: " << stored_file_name << std::endl;
-	}
-	if (remove(extracted_file_name.c_str()) != 0) {
-		std::cout << "Error removing file: " << extracted_file_name << std::endl;
-	}
-	
-}
+	        std::vector<std::vector<uint8_t>> file_buffer = pdf.ExtractFile();
 
-std::string PDFParser::extract_text_buffer()
-{
-    return exc_extract_text_buffer();
-}
+	        return file_buffer;
+        }
 
-std::string PDFParser::exc_extract_text_buffer()
-{
-    char *cmd = NULL;   
-    try {
-    	
-        char * cmd = new char[12 + stored_file_name.size() + extracted_file_name.size()];
-        
-        strcpy(cmd, pdf_to_text);
-        strcat(cmd, " ");
-        strcat(cmd, stored_file_name.c_str());
-        strcat(cmd, " ");
-        strcat(cmd, extracted_file_name.c_str());
-        system(cmd);
+    } // !namespace pdfparser
 
-        std::ifstream ifs(extracted_file_name.c_str());
-        std::string content( (std::istreambuf_iterator<char>(ifs) ),
-        		(std::istreambuf_iterator<char>()) );
-
-        delete[] cmd;
-        return content;
-    } catch (std::exception e) {
-
-        if(cmd) {delete[] cmd;}
-
-        syslog (LOG_INFO|LOG_LOCAL6, "PDFParser encountered fatal error");
-        return "";
-    }
-}
-
-
-int PDFParser::has_embedded_files()
-{
-	
-	// returns 0 or the number of files detected as emebedded
-	char *cmd = new char[8 + strlen(pdf_detach) + stored_file_name.size()];
-	
-    strcpy(cmd, pdf_detach);
-    strcat(cmd, " -list ");
-    strcat(cmd, stored_file_name.c_str());
-	
-    std::string stmp = std::string(get_stdout_cmd(cmd), 0, 3);
-    /*
-     * we will take 3 bytes above so that should cover some
-     * pretty crazy situations cause that represents a lot
-     * of attachments.
-     * 
-     * Might tweak that later to less.
-     * 
-     * atoi gets rid of chars that don't convert cleanly
-     * to int types so no extra work needed there it seems.
-     * And if there is no conversion i_auto gets zero
-     */
-    int i_auto = atoi(stmp.c_str());
-    delete[] cmd;
-	return i_auto;
-}
-
+} // !extern "C"

--- a/libs/pdf_parser.cpp
+++ b/libs/pdf_parser.cpp
@@ -1,10 +1,31 @@
-//============================================================================
-// Name        : PDFParser.cpp
-// Author      : Rodrigo de Francisco
-// Version     :
-// Copyright   : Your copyright notice
-// Description : Hello World in C++, Ansi-style
-//============================================================================
+/*****************************************************************************
+ *
+ * YEXTEND: Help for YARA users.
+ * This file is part of yextend.
+ *
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
 
 /* Include order
 Own .h.

--- a/libs/pdf_parser.cpp
+++ b/libs/pdf_parser.cpp
@@ -1,61 +1,75 @@
-/*****************************************************************************
- *
- * YEXTEND: Help for YARA users.
- * This file is part of yextend.
- *
- * Copyright (c) 2014-2018, Bayshore Networks, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- * the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- * following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
+//============================================================================
+// Name        : PDFParser.cpp
+// Author      : Rodrigo de Francisco
+// Version     :
+// Copyright   : Your copyright notice
+// Description : Hello World in C++, Ansi-style
+//============================================================================
 
-#include "pdf_parser_helper.h"
-#include "pdf.h"
+/* Include order
+Own .h.
+C.
+C++.
+Other libraries' .h files.
+Your project's .h files.
+*/
+
+#include "pdf_parser.h"
+
+//#include "pdf.h"
+
 
 extern "C" {
 
-    namespace pdfparser {
+namespace pdfparser {
 
-        /**
-         *
-         * @param pdf_pointer pointer where the pdf is loaded
-         * @param pdf_size size of pdf
-         * @return vector with decoded text. Text blocks are separated by \n. User should copy the decoded text.
-         */
-        std::vector<uint8_t> PdfToText (const uint8_t* pdf_pointer, size_t pdf_size) {
-	        Pdf pdf{pdf_pointer, pdf_size};
 
-	        std::vector<uint8_t> text_buffer = pdf.ExtractText();
+/**
+ *
+ * @param pdf_pointer pointer where the pdf is loaded
+ * @param pdf_size size of pdf
+ * @return vector with decoded text. Text blocks are separated by \n. User should copy the decoded text.
+ */
+std::vector<uint8_t> PdfToText (const uint8_t* pdf_pointer, size_t pdf_size, pdfparser::TextEncoding encoding) {
 
-	        return text_buffer;
-        }
+	Pdf pdf{pdf_pointer, pdf_size};
+	auto text_buffer = pdf.ExtractText(encoding); // TODO BS-54
+	return text_buffer;
+}
 
-        std::vector<std::vector<uint8_t>> PdfDetach (const uint8_t* pdf_pointer, size_t pdf_size) {
-	        Pdf pdf{pdf_pointer, pdf_size};
 
-	        std::vector<std::vector<uint8_t>> file_buffer = pdf.ExtractFile();
+PDF_DETACH PdfDetach (const uint8_t* pdf_pointer, size_t pdf_size) {
 
-	        return file_buffer;
-        }
+	Pdf pdf{pdf_pointer, pdf_size};
+	std::vector<std::vector<uint8_t>> file_buffer = pdf.ExtractFile(); // TODO BS-54
+	return file_buffer;
+}
 
-    } // !namespace pdfparser
+
+
+	// TODO BS-55
+	/*
+	std::vector<std::vector<uint8_t>> files_buffer{}; // To store files
+	auto current_pdf_pointer = pdf_pointer;
+	auto current_pdf_size = pdf_size;
+	std::vector<std::string> file_obj_pointers{};	// Pointers to objects containing '/Type Filespec'
+
+	//Pdf pdf{current_pdf_pointer, current_pdf_size};
+
+	while (current_pdf_size > 0 && current_pdf_size != std::string::npos){
+		PdfObject pdf_object{current_pdf_pointer, current_pdf_size};
+
+		//pdf_object.ExtractFileObjects();
+		//current_text = pdf_object.DecodeText(); // Get the actual text
+
+
+
+		current_pdf_size = current_pdf_size - (pdf_object.GetObjectEnd() - current_pdf_pointer);
+		current_pdf_pointer = pdf_object.GetObjectEnd();
+	}
+	return std::vector<std::vector<uint8_t>>{};
+*/
+
+} // !namespace pdfparser
 
 } // !extern "C"

--- a/libs/pdf_parser.h
+++ b/libs/pdf_parser.h
@@ -1,9 +1,31 @@
-/*
- * pdfparser.h
+/*****************************************************************************
  *
- *  Created on: Nov 29, 2017
- *      Author: rodrigo
- */
+ * YEXTEND: Help for YARA users.
+ * This file is part of yextend.
+ *
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
 
 #ifndef PDF_PARSER_H_
 #define PDF_PARSER_H_

--- a/libs/pdf_parser.h
+++ b/libs/pdf_parser.h
@@ -24,7 +24,7 @@ extern "C" {
 using PDF_DETACH = std::vector<std::vector<uint8_t>>;
 
 
-std::vector<uint8_t> PdfToText (const uint8_t* pdf_start, size_t pdf_size, TextEncoding encoding);
+std::vector<uint8_t> PdfToText (const uint8_t* pdf_start, size_t pdf_size, pdfparser::TextEncoding encoding = TextEncoding::raw);
 
 PDF_DETACH PdfDetach (const uint8_t* pdf_start, size_t pdf_size);
 

--- a/libs/pdf_parser.h
+++ b/libs/pdf_parser.h
@@ -1,49 +1,34 @@
-/*****************************************************************************
+/*
+ * pdfparser.h
  *
- * YEXTEND: Help for YARA users.
- * This file is part of yextend.
- *
- * Copyright (c) 2014-2018, Bayshore Networks, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- * the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- * following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
+ *  Created on: Nov 29, 2017
+ *      Author: rodrigo
+ */
 
 #ifndef PDF_PARSER_H_
 #define PDF_PARSER_H_
 
-#include <cstddef>
 #include <stdint.h>
+
+#include <cstddef>
 #include <vector>
 
 #include "pdf.h"
+#include "pdf_text_encoding.h"
 
 namespace pdfparser {
 
-    extern "C" {
+extern "C" {
 
-        std::vector<uint8_t> PdfToText (const uint8_t* pdf_start, size_t pdf_size);
-        std::vector<std::vector<uint8_t>> PdfDetach (uint8_t* pdf_start, size_t pdf_size);
 
-    } // !extern "C"
+using PDF_DETACH = std::vector<std::vector<uint8_t>>;
+
+
+std::vector<uint8_t> PdfToText (const uint8_t* pdf_start, size_t pdf_size, TextEncoding encoding);
+
+PDF_DETACH PdfDetach (const uint8_t* pdf_start, size_t pdf_size);
+
+} // !extern "C"
 
 } // !namespace pdfparser
 

--- a/libs/pdf_parser_helper.cpp
+++ b/libs/pdf_parser_helper.cpp
@@ -1,31 +1,16 @@
-/*****************************************************************************
+/*
  *
- * YEXTEND: Help for YARA users.
- * This file is part of yextend.
- *
- * Copyright (c) 2014-2018, Bayshore Networks, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- * the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- * following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
+ *  Created on: Nov 29, 2017
+ *      Author: rodrigo
+ */
+
+/* Include order
+Own .h.
+C.
+C++.
+Other libraries' .h files.
+Your project's .h files.
+*/
 
 #include <cstring>
 
@@ -40,123 +25,123 @@
 #include <sstream>
 #include <vector>
 
+
 namespace pdfparser {
 
-    extern "C" {
+extern "C" {
 
-        /**
-         * @brief Returns the position of the first needle in the haystack
-         * @param haystack
-         * @param needle
-         * @param haystack_size
-         * @return size_t position in haystack where needle is located
-         */
-        size_t FindStringInBuffer (const uint8_t* haystack, const char* needle, const size_t haystack_size) {
-	        auto haystack_index = haystack;
 
-	        size_t needle_length = std::char_traits<char>::length(needle);
+/**
+ * @brief Returns the position of the first needle in the haystack
+ * @param haystack
+ * @param needle
+ * @param haystack_size
+ * @return size_t position in haystack where needle is located
+ */
+size_t FindStringInBuffer (const uint8_t* haystack, const char* needle, const size_t haystack_size) {
+	auto haystack_index = haystack;
 
-	        bool found = false;
-	        while (!found) {
-		        found = true;
-		        for (size_t i=0; i<needle_length; ++i) {
-			        if (haystack_index[i]!=needle[i]) {
-				        found = false;
-				        break;
-			        }
-		        }
+	size_t needle_length = std::char_traits<char>::length(needle);
 
-		        if (found)
-                    return haystack_index - haystack;
+	bool found = false;
+	while (!found) {
+		found = true;
+		for (size_t i=0; i<needle_length; ++i) {
+			if (haystack_index[i]!=needle[i]) {
+				found = false;
+				break;
+			}
+		}
+		if (found) return haystack_index - haystack;
+		haystack_index++;
+		if (haystack_index - haystack + needle_length >= haystack_size){
+			return std::string::npos;
+		}
+	}
+	return std::string::npos;
+}
 
-		        haystack_index++;
 
-		        if (haystack_index - haystack + needle_length >= haystack_size)
-			        return std::string::npos;
-	        }
+size_t FindStringInBufferReverse (const uint8_t* haystack, const char* needle, const size_t haystack_size) {
+	auto haystack_index = haystack+haystack_size;
 
-	        return std::string::npos;
-        }
+	size_t needle_length = std::char_traits<char>::length(needle);
 
-        size_t FindStringInBufferReverse (const uint8_t* haystack, const char* needle, const size_t haystack_size) {
-	        auto haystack_index = haystack+haystack_size;
+	bool found = false;
+	while (!found) {
+		found = true;
+		for (size_t i=1; i<needle_length; ++i) { //Starts in 1 to avoid '/0' at the end of needle. Length is 1 based and needle is 0 based
+			if (haystack_index[-i]!=needle[needle_length-i]) { // reversed direction
+				found = false;
+				break;
+			}
+		}
+		if (found) return haystack_index - haystack;
+		--haystack_index;
+		if (haystack_index - haystack - needle_length == 0){ // Begin of haystack reached
+			return std::string::npos;
+		}
+	}
+	return std::string::npos;
+}
 
-	        size_t needle_length = std::char_traits<char>::length(needle);
 
-	        bool found = false;
-	        while (!found) {
-		        found = true;
-		        for (size_t i=1; i<needle_length; ++i) { //Starts in 1 to avoid '/0' at the end of needle. Length is 1 based and needle is 0 based
-			        if (haystack_index[-i]!=needle[needle_length-i]) { // reversed direction
-				        found = false;
-				        break;
-			        }
-		        }
-		        if (found)
-                    return haystack_index - haystack;
+/**
+ * @brief Splits the string in 'quantity' pieces using delim as delimiter
+ * @param string	is the string to be splitted
+ * @param delim		string is splitted using this char as delimiter
+ * @param quantity	is the quantity of splits. 1 return de first split and the rest. If std::string::npos it splits the whole string
+ * @return
+ */
+std::vector<std::string> SplitString(std::string const & string, char delim, size_t quantity=std::string::npos)
+{
+    std::vector<std::string> result;
+    std::istringstream iss(string);
 
-		        --haystack_index;
+    std::string token;
+    while (std::getline(iss, token, delim) && quantity > 0)
+    //for (std::string token; std::getline(iss, token, delim); )
+    {
+    	result.push_back(std::move(token));
+    	quantity--;
+    }
+    if (quantity == 0){
+    	result.push_back(std::move(token));
+    }
+    return result;
+}
 
-		        if (haystack_index - haystack - needle_length == 0) { // Begin of haystack reached
-			        return std::string::npos;
-		        }
-	        }
-	        return std::string::npos;
-        }
+/**
+ * @brief	Splits the string by any of the characters included in delim
+ * @param string
+ * @param delim
+ * @return
+ */
+std::vector<std::string> SplitStringAnyChar(std::string const & string, std::string const & delim, size_t quantity) {
+	std::vector<std::string> word_vector{};
+	std::stringstream stringStream(string);
+	std::string line;
 
-        /**
-         * @brief Splits the string in 'quantity' pieces using delim as delimiter
-         * @param string	is the string to be splitted
-         * @param delim		string is splitted using this char as delimiter
-         * @param quantity	is de quantity of splits. 1 return de first split and the rest. If std::string::npos it splits the whole string
-         * @return
-         */
-        std::vector<std::string> SplitString(std::string const & string, char delim, size_t quantity) {
-            std::vector<std::string> result;
-            std::istringstream iss(string);
+	while(std::getline(stringStream, line)) {
+		std::size_t prev = 0, pos;
 
-            std::string token;
-            while (std::getline(iss, token, delim) && quantity > 0) {
-            	result.push_back(std::move(token));
-            	quantity--;
-            }
+		while (((pos = line.find_first_of(delim, prev)) != std::string::npos) && (quantity >0))
+		{
+			if (pos > prev) {
+				word_vector.push_back(line.substr(prev, pos-prev));
+				--quantity;
+			}
+			prev = pos+1;
+		}
+		if ((prev < line.length()) || (quantity == 0))
+			word_vector.push_back(line.substr(prev, std::string::npos));
+	}
 
-            if (quantity == 0)
-            	result.push_back(std::move(token));
+	return word_vector;
+}
 
-            return result;
-        }
 
-        /**
-         * @brief	Splits the string by any of the characters included in delim
-         * @param string
-         * @param delim
-         * @return
-         */
-        std::vector<std::string> SplitStringAnyChar(std::string const & string, std::string const & delim, size_t quantity) {
-	        std::vector<std::string> word_vector{};
-	        std::stringstream stringStream(string);
-	        std::string line;
-
-	        while(std::getline(stringStream, line)) {
-		        std::size_t prev = 0, pos;
-
-		        while (((pos = line.find_first_of(delim, prev)) != std::string::npos) && (quantity >0)) {
-			        if (pos > prev) {
-				        word_vector.push_back(line.substr(prev, pos-prev));
-				        --quantity;
-			        }
-
-			        prev = pos+1;
-		        }
-
-		        if ((prev < line.length()) || (quantity == 0))
-			        word_vector.push_back(line.substr(prev, std::string::npos));
-	        }
-
-	        return word_vector;
-        }
-
-    } // !extern "C"
+} // !extern "C"
 
 } // !namespace pdfparser
+

--- a/libs/pdf_parser_helper.cpp
+++ b/libs/pdf_parser_helper.cpp
@@ -1,0 +1,162 @@
+/*****************************************************************************
+ *
+ * YEXTEND: Help for YARA users.
+ * This file is part of yextend.
+ *
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+
+#include <cstring>
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <istream>
+#include <iostream> //debugging
+#include <list>
+#include <regex>
+#include <string>
+#include <sstream>
+#include <vector>
+
+namespace pdfparser {
+
+    extern "C" {
+
+        /**
+         * @brief Returns the position of the first needle in the haystack
+         * @param haystack
+         * @param needle
+         * @param haystack_size
+         * @return size_t position in haystack where needle is located
+         */
+        size_t FindStringInBuffer (const uint8_t* haystack, const char* needle, const size_t haystack_size) {
+	        auto haystack_index = haystack;
+
+	        size_t needle_length = std::char_traits<char>::length(needle);
+
+	        bool found = false;
+	        while (!found) {
+		        found = true;
+		        for (size_t i=0; i<needle_length; ++i) {
+			        if (haystack_index[i]!=needle[i]) {
+				        found = false;
+				        break;
+			        }
+		        }
+
+		        if (found)
+                    return haystack_index - haystack;
+
+		        haystack_index++;
+
+		        if (haystack_index - haystack + needle_length >= haystack_size)
+			        return std::string::npos;
+	        }
+
+	        return std::string::npos;
+        }
+
+        size_t FindStringInBufferReverse (const uint8_t* haystack, const char* needle, const size_t haystack_size) {
+	        auto haystack_index = haystack+haystack_size;
+
+	        size_t needle_length = std::char_traits<char>::length(needle);
+
+	        bool found = false;
+	        while (!found) {
+		        found = true;
+		        for (size_t i=1; i<needle_length; ++i) { //Starts in 1 to avoid '/0' at the end of needle. Length is 1 based and needle is 0 based
+			        if (haystack_index[-i]!=needle[needle_length-i]) { // reversed direction
+				        found = false;
+				        break;
+			        }
+		        }
+		        if (found)
+                    return haystack_index - haystack;
+
+		        --haystack_index;
+
+		        if (haystack_index - haystack - needle_length == 0) { // Begin of haystack reached
+			        return std::string::npos;
+		        }
+	        }
+	        return std::string::npos;
+        }
+
+        /**
+         * @brief Splits the string in 'quantity' pieces using delim as delimiter
+         * @param string	is the string to be splitted
+         * @param delim		string is splitted using this char as delimiter
+         * @param quantity	is de quantity of splits. 1 return de first split and the rest. If std::string::npos it splits the whole string
+         * @return
+         */
+        std::vector<std::string> SplitString(std::string const & string, char delim, size_t quantity) {
+            std::vector<std::string> result;
+            std::istringstream iss(string);
+
+            std::string token;
+            while (std::getline(iss, token, delim) && quantity > 0) {
+            	result.push_back(std::move(token));
+            	quantity--;
+            }
+
+            if (quantity == 0)
+            	result.push_back(std::move(token));
+
+            return result;
+        }
+
+        /**
+         * @brief	Splits the string by any of the characters included in delim
+         * @param string
+         * @param delim
+         * @return
+         */
+        std::vector<std::string> SplitStringAnyChar(std::string const & string, std::string const & delim, size_t quantity) {
+	        std::vector<std::string> word_vector{};
+	        std::stringstream stringStream(string);
+	        std::string line;
+
+	        while(std::getline(stringStream, line)) {
+		        std::size_t prev = 0, pos;
+
+		        while (((pos = line.find_first_of(delim, prev)) != std::string::npos) && (quantity >0)) {
+			        if (pos > prev) {
+				        word_vector.push_back(line.substr(prev, pos-prev));
+				        --quantity;
+			        }
+
+			        prev = pos+1;
+		        }
+
+		        if ((prev < line.length()) || (quantity == 0))
+			        word_vector.push_back(line.substr(prev, std::string::npos));
+	        }
+
+	        return word_vector;
+        }
+
+    } // !extern "C"
+
+} // !namespace pdfparser

--- a/libs/pdf_parser_helper.cpp
+++ b/libs/pdf_parser_helper.cpp
@@ -1,8 +1,31 @@
-/*
+/*****************************************************************************
  *
- *  Created on: Nov 29, 2017
- *      Author: rodrigo
- */
+ * YEXTEND: Help for YARA users.
+ * This file is part of yextend.
+ *
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
 
 /* Include order
 Own .h.
@@ -144,4 +167,3 @@ std::vector<std::string> SplitStringAnyChar(std::string const & string, std::str
 } // !extern "C"
 
 } // !namespace pdfparser
-

--- a/libs/pdf_parser_helper.h
+++ b/libs/pdf_parser_helper.h
@@ -1,34 +1,12 @@
-/*****************************************************************************
+/*
+ * parser.h
  *
- * YEXTEND: Help for YARA users.
- * This file is part of yextend.
- *
- * Copyright (c) 2014-2018, Bayshore Networks, Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
- * the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
- * following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
- * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *****************************************************************************/
+ *  Created on: Nov 29, 2017
+ *      Author: rodrigo
+ */
 
-#ifndef PDF_PARSER_HELPER_H_
-#define PDF_PARSER_HELPER_H_
+#ifndef PARSER_HELPER_H_
+#define PARSER_HELPER_H_
 
 #include <stdint.h>
 
@@ -37,16 +15,19 @@
 #include <unordered_map>
 #include <vector>
 
+
+
 namespace pdfparser {
 
-    extern "C" {
+extern "C" {
 
-        size_t FindStringInBuffer (const uint8_t* haystack, const char* needle, const size_t haystack_size);
-        size_t FindStringInBufferReverse (const uint8_t* haystack, const char* needle, const size_t haystack_size);
-        std::vector<std::string> SplitString(std::string const & string, char delim, size_t quantity = std::string::npos);
+size_t FindStringInBuffer (const uint8_t* haystack, const char* needle, const size_t haystack_size);
+size_t FindStringInBufferReverse (const uint8_t* haystack, const char* needle, const size_t haystack_size);
+std::vector<std::string> SplitString(std::string const & string, char delim, size_t quantity = std::string::npos);
 
-    } // !extern "C"
+} // !extern "C"
 
 } // !namespace pdfparser
 
-#endif /* PDF_PARSER_HELPER_H_ */
+
+#endif /* PARSER_HELPER_H_ */

--- a/libs/pdf_parser_helper.h
+++ b/libs/pdf_parser_helper.h
@@ -27,24 +27,26 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
 
-#ifndef PDF_PARSER_H_
-#define PDF_PARSER_H_
+#ifndef PDF_PARSER_HELPER_H_
+#define PDF_PARSER_HELPER_H_
+
+#include <stdint.h>
 
 #include <cstddef>
-#include <stdint.h>
+#include <string>
+#include <unordered_map>
 #include <vector>
-
-#include "pdf.h"
 
 namespace pdfparser {
 
     extern "C" {
 
-        std::vector<uint8_t> PdfToText (const uint8_t* pdf_start, size_t pdf_size);
-        std::vector<std::vector<uint8_t>> PdfDetach (uint8_t* pdf_start, size_t pdf_size);
+        size_t FindStringInBuffer (const uint8_t* haystack, const char* needle, const size_t haystack_size);
+        size_t FindStringInBufferReverse (const uint8_t* haystack, const char* needle, const size_t haystack_size);
+        std::vector<std::string> SplitString(std::string const & string, char delim, size_t quantity = std::string::npos);
 
     } // !extern "C"
 
 } // !namespace pdfparser
 
-#endif /* PDF_PARSER_H_ */
+#endif /* PDF_PARSER_HELPER_H_ */

--- a/libs/pdf_parser_helper.h
+++ b/libs/pdf_parser_helper.h
@@ -1,9 +1,31 @@
-/*
- * parser.h
+/*****************************************************************************
  *
- *  Created on: Nov 29, 2017
- *      Author: rodrigo
- */
+ * YEXTEND: Help for YARA users.
+ * This file is part of yextend.
+ *
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
 
 #ifndef PARSER_HELPER_H_
 #define PARSER_HELPER_H_

--- a/libs/pdf_text_encoding.h
+++ b/libs/pdf_text_encoding.h
@@ -1,0 +1,21 @@
+#ifndef TEXT_ENCODING_H_
+#define TEXT_ENCODING_H_
+
+namespace pdfparser {
+
+
+extern "C" {
+
+
+enum class TextEncoding {
+	raw,
+	utf8
+};
+
+
+} // !extern C
+
+
+} // !namespace
+
+#endif // TEXT_ENCODING_H_

--- a/libs/pdf_text_encoding.h
+++ b/libs/pdf_text_encoding.h
@@ -1,3 +1,32 @@
+/*****************************************************************************
+ *
+ * YEXTEND: Help for YARA users.
+ * This file is part of yextend.
+ *
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ * the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+
 #ifndef TEXT_ENCODING_H_
 #define TEXT_ENCODING_H_
 

--- a/main.cpp
+++ b/main.cpp
@@ -3,21 +3,21 @@
  * YEXTEND: Help for YARA users.
  * This file is part of yextend.
  *
- * Copyright (c) 2014-2017, Bayshore Networks, Inc.
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
  * following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
  * following disclaimer in the documentation and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
  * products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
@@ -184,16 +184,16 @@ bool does_this_file_exist(const char *fn) {
 }
 
 double get_yara_version() {
-	
+
 	/*
 	 * older versions of yara seem to output version like this:
-	 * 
+	 *
 	 * yara 3.4.0
-	 * 
+	 *
 	 * while the later ones just do:
-	 * 
+	 *
 	 * 3.6.0
-	 * 
+	 *
 	 */
 	FILE *fp;
 	double yara_version = 0.0;
@@ -211,14 +211,14 @@ double get_yara_version() {
 			if (found != std::string::npos) {
 				yver_str = yver_str.substr(found + 5);
 			}
-			
+
 			//yara_version = strtod(yver, NULL);
 			yara_version = strtod(yver_str.c_str(), NULL);
 
 		}
-		
+
 		pclose(fp);
-		
+
 	}
 
 	return yara_version;
@@ -244,19 +244,19 @@ void tokenize_string (
 			tokens.push_back(token);
 		}
 	}
-	
+
 }
 
 std::string process_scan_hit_str(const std::string &hit_str,
-		const std::string &file_scan_type, 
+		const std::string &file_scan_type,
 		const std::string &file_signature_md5,
 		const std::string &parent_file_name,
 		const std::string &child_file_name
 		) {
-	
+
 	std::string resp = "";
-	
-	bool b = regex_search(hit_str, mtch, yara_meta);							    
+
+	bool b = regex_search(hit_str, mtch, yara_meta);
 	if (b) {
 
 		std::string yara_rule_hit_name = mtch[1];
@@ -278,35 +278,35 @@ std::string process_scan_hit_str(const std::string &hit_str,
 			//std::string k = tokens_3[0];
 			//std::string v = tokens_3[1];
 			if (tokens_3[0] == "detected offsets") {
-				
+
 				json j_meta_do;
 				std::vector<std::string> tokens_4;
 				tokenize_string (tokens_3[1], tokens_4, "-");
-				
+
 				if (tokens_4.size() == 0) {
-					
+
 					j_meta_do.push_back(tokens_3[1]);
-					
+
 				} else {
-				
+
 					for (auto& it4 : tokens_4) {
 						j_meta_do.push_back(it4);
 					}
-				
+
 				}
-				
+
 				j_meta[tokens_3[0]] = j_meta_do;
-				
+
 			} else {
 				j_meta[tokens_3[0]] = tokens_3[1];
 			}
 
 		}
-		
+
 		j_meta[json_output_labels[3]] = file_scan_type;
 		j_meta[json_output_labels[4]] = file_signature_md5;
 		j_meta[json_output_labels[12]] = yara_rule_hit_name;
-		
+
 		if (parent_file_name.size()) {
 			if (child_file_name.size()) {
 				if (parent_file_name != child_file_name) {
@@ -325,9 +325,9 @@ std::string process_scan_hit_str(const std::string &hit_str,
 		}
 
 	}
-	
+
 	return resp;
-	
+
 }
 
 
@@ -339,19 +339,19 @@ std::string process_scan_no_hit(bool hit,
 		const std::string &child_file_name,
 		size_t file_size
 		) {
-	
+
 	std::string resp;
 
 	json j_results;
 	j_results[json_output_labels[10]] = hit;
-	
+
 	if (file_scan_result.size() > 0) {
 		j_results[json_output_labels[12]] = file_scan_result;
 	}
-	
+
 	j_results[json_output_labels[3]] = file_scan_type;
 	j_results[json_output_labels[4]] = file_signature_md5;
-	
+
 	if (parent_file_name.size()) {
 		if (child_file_name.size()) {
 			if (parent_file_name != child_file_name) {
@@ -364,17 +364,17 @@ std::string process_scan_no_hit(bool hit,
 			j_results[json_output_labels[5]] = parent_file_name;
 		}
 	}
-	
+
 	if (file_size > 0) {
 		j_results[json_output_labels[1]] = file_size;
 	}
-	
+
 	if (!j_results.is_null()) {
 		resp = j_results.dump();
 	}
 
 	return resp;
-	
+
 }
 
 
@@ -385,7 +385,7 @@ void legacy_output(const std::string &file_scan_result,
 		const std::string &child_file_name,
 		size_t file_size
 		) {
-	
+
 	std::cout << std::endl;
 	std::cout << output_labels[2] << file_scan_result << std::endl;
 	std::cout << output_labels[3] << file_scan_type << std::endl;
@@ -426,7 +426,7 @@ json parse_json_string(std::string j_dat) {
 		std::cout << json_exception << " : " << e.what() << std::endl;
 	}
 	return j_null;
-	
+
 }
 
 ///////////////////////////////////////////////////////////////
@@ -499,70 +499,70 @@ int main(int argc, char* argv[]) {
 		std::cout << std::endl << "Problem compiling Yara Ruleset file: \"" << yara_ruleset_file_name << "\", continuing with regular ruleset file ..." << std::endl << std::endl;
 	}
 
-	
+
 	try {
-	
+
 		json j_main;
-	
+
 		if (is_directory(target_resource.c_str())) {
-	
+
 			DIR *dpdf;
 			struct dirent *epdf;
-	
+
 			dpdf = opendir(target_resource.c_str());
 			if (dpdf != NULL) {
-				
+
 				while (epdf = readdir(dpdf)) {
-	
+
 					json j_level1;
-					
+
 					uint8_t *c;
 					FILE *file = NULL;
-	
+
 					strncpy (fs, target_resource.c_str(), sizeof(fs));
 					fs[sizeof(fs)-1]= '\0'; //fs[strlen(target_resource.c_str())] = '\0';
-					
+
 					if (epdf->d_name[0] != '.') {
-						
+
 						json j_children;
-	
+
 						strncat (fs, epdf->d_name, strlen(epdf->d_name));
 						fs[strlen(fs)] = '\0';
-	
+
 						if (is_directory(fs)) {
 							// We do not recurse into directories yet
 							continue;
 						}
-	
+
 						if ((file = fopen(fs, "rb")) != NULL) {
 							// Get the size of the file in bytes
 							size_t file_size = get_file_size(fs);
-	
+
 							// Allocate space in the buffer for the whole file
 							c = new uint8_t[file_size];
 							// Read the file in to the buffer
 							size_t dat_read = fread(c, 1, file_size, file);
-							
+
 							if (dat_read == file_size) {
-		
+
 								if (!out_json) {
-									
+
 									std::cout << std::endl << alpha << std::endl;
 									std::cout << output_labels[8] << yara_ruleset_file_name << std::endl;
 									std::cout << output_labels[0] << fs << std::endl;
 									std::cout << output_labels[1] << file_size << std::endl;
-								
+
 								} else {
-		
+
 									j_level1[json_output_labels[8]] = yara_ruleset_file_name;
 									j_level1[json_output_labels[0]] = fs;
-									j_level1[json_output_labels[1]] = file_size;							
-									
+									j_level1[json_output_labels[1]] = file_size;
+
 								}
-		
+
 								char *output = str_to_md5((const char *)c, file_size);
 								if (output) {
-		
+
 									if (!out_json) {
 										std::cout << output_labels[4] << output << std::endl;
 									} else {
@@ -570,11 +570,11 @@ int main(int argc, char* argv[]) {
 									}
 									free(output);
 								}
-		
+
 								std::list<security_scan_results_t> ssr_list;
-		
+
 								if (rules) {
-		
+
 									scan_content (
 											c,
 											file_size,
@@ -583,9 +583,9 @@ int main(int argc, char* argv[]) {
 											fs,
 											yara_cb,
 											1);
-		
+
 								} else {
-									
+
 									scan_content (
 											c,
 											file_size,
@@ -594,21 +594,21 @@ int main(int argc, char* argv[]) {
 											fs,
 											yara_cb,
 											1);
-									
+
 								}
-		
+
 								if (!ssr_list.empty()) {
-		
+
 									if (!out_json) {
 										std::cout << std::endl << midline << std::endl;
 									}
-									
+
 									for (std::list<security_scan_results_t>::const_iterator v = ssr_list.begin();
 											v != ssr_list.end();
 											v++) {
-										
+
 										if (!out_json) {
-											
+
 											legacy_output(v->file_scan_result,
 													v->file_scan_type,
 													v->file_signature_md5,
@@ -616,59 +616,59 @@ int main(int argc, char* argv[]) {
 													v->child_file_name,
 													v->file_size
 													);
-										
+
 										} else {
-											
+
 											std::string file_scan_result = v->file_scan_result;
 											if (file_scan_result.size() > 1) {
-		
+
 												j_level1[json_output_labels[10]] = true;
-												
+
 											}
-											
+
 											std::vector<std::string> tokens;
 											std::string delim = meta_delim;
 											delim.append(" ");
 											tokenize_string (file_scan_result, tokens, delim);
-											
+
 											// we have hits
 											if (file_scan_result.size()) {
-											
+
 												// we have multiple hits
 												if (tokens.size() > 0) {
-													
+
 													for (auto& it : tokens) {
-														
+
 														std::string pshs_resp = process_scan_hit_str(it,
-																v->file_scan_type, 
+																v->file_scan_type,
 																v->file_signature_md5,
 																v->parent_file_name,
 																v->child_file_name);
-														
+
 														if (pshs_resp.size()) {
-	
+
 															auto jresp = parse_json_string(pshs_resp);
 															if (!jresp.is_null()) {
 																jresp[json_output_labels[10]] = true;
 																jresp[json_output_labels[1]] = v->file_size;
 																j_children.push_back(jresp);
 															}
-															
+
 														} else {
-															
+
 															/*
 															 * here we have rule hits with not much
 															 * in the way of meta-data, an example
 															 * of a rule like this:
-															 * 
+															 *
 															 *     rule is_entropy
 															 *     {
 															 *         condition:
 															 *             math.entropy(0,filesize)>5
 															 *     }
-															 * 
-															 * 
-															 */													
+															 *
+															 *
+															 */
 															std::string j_no_hit = process_scan_no_hit(true,
 																	it,
 																	v->file_scan_type,
@@ -678,37 +678,37 @@ int main(int argc, char* argv[]) {
 																	v->file_size
 																	);
 															if (j_no_hit.size() > 0) {
-																
+
 																auto jnh = parse_json_string(j_no_hit);
 																if (!jnh.is_null()) {
 																	j_children.push_back(jnh);
 																}
-																
+
 															}
-															
+
 														}
-														
+
 													}
-													
+
 												} else { // we have single hit
-													
+
 													std::string pshs_resp = process_scan_hit_str(file_scan_result,
-															v->file_scan_type, 
+															v->file_scan_type,
 															v->file_signature_md5,
 															v->parent_file_name,
 															v->child_file_name);
-													
+
 													if (pshs_resp.size()) {
-	
+
 														auto jresp = parse_json_string(pshs_resp);
 														if (!jresp.is_null()) {
 															jresp[json_output_labels[10]] = true;
 															jresp[json_output_labels[1]] = v->file_size;
 															j_children.push_back(jresp);
 														}
-														
+
 													} else {
-		
+
 														std::string j_no_hit = process_scan_no_hit(true,
 																file_scan_result,
 																v->file_scan_type,
@@ -718,20 +718,20 @@ int main(int argc, char* argv[]) {
 																v->file_size
 																);
 														if (j_no_hit.size() > 0) {
-															
+
 															auto jnh = parse_json_string(j_no_hit);
 															if (!jnh.is_null()) {
 																j_children.push_back(jnh);
 															}
-															
+
 														}
-														
+
 													}
-													
+
 												}
-											
+
 											} else { // no hits just display meta data
-		
+
 												std::string j_no_hit = process_scan_no_hit(false,
 														"",
 														v->file_scan_type,
@@ -741,116 +741,116 @@ int main(int argc, char* argv[]) {
 														v->file_size
 														);
 												if (j_no_hit.size() > 0) {
-													
+
 													auto jnh = parse_json_string(j_no_hit);
 													if (!jnh.is_null()) {
 														j_children.push_back(jnh);
 													}
-													
+
 												}
-												
+
 											}
-											
+
 										}
-										
+
 									}
-									
+
 									if (!out_json) {
 										std::cout << std::endl << omega << std::endl;
 									}
-									
+
 								} else {
-									
+
 									if (!out_json) {
 										std::cout << std::endl << omega << std::endl;
 									}
-									
+
 								}
-							
+
 							}
-	
+
 							delete[] c;
 							fclose(file);
-	
+
 						}
-						
+
 						if (!j_children.is_null()) {
 							j_level1[json_output_labels[13]] = j_children;
 						}
-					
+
 					} else {
-						
+
 						continue;
-						
+
 					}
-	
+
 					if (!j_level1.is_null()) {
 						j_main.push_back(j_level1);
 					}
-	
+
 				}
-	
+
 				closedir(dpdf);
-	
+
 			}
-			
+
 		} else if (does_this_file_exist(target_resource.c_str())) {
-	
+
 			uint8_t *c;
 			FILE *file = NULL;
 			strncpy (fs, target_resource.c_str(), sizeof(fs));
 			fs[sizeof(fs)-1]= '\0'; //fs[strlen(target_resource.c_str())] = '\0';
-	
-			
+
+
 			if (fs[0] != '.') {
-	
+
 				json j_level1;
 				json j_children;
-				
+
 				if ((file = fopen(fs, "rb")) != NULL) {
-					
+
 					// Get the size of the file in bytes
 					size_t file_size = get_file_size(fs);
-	
+
 					// Allocate space in the buffer for the whole file
 					c = new uint8_t[file_size];
-	
+
 					// Read the file in to the buffer
 					//fread(c, file_size, 1, file);
 					size_t dat_read = fread(c, 1, file_size, file);
-					
+
 					if (dat_read == file_size) {
-		
+
 						if (!out_json) {
-		
+
 							std::cout << std::endl << alpha << std::endl;
 							std::cout << output_labels[0] << fs << std::endl;
 							std::cout << output_labels[1] << file_size << std::endl;
-		
+
 						} else {
-		
+
 							j_level1[json_output_labels[8]] = yara_ruleset_file_name;
 							j_level1[json_output_labels[0]] = fs;
 							j_level1[json_output_labels[1]] = file_size;
-		
+
 						}
-		
+
 						char *output = str_to_md5((const char *)c, file_size);
 						if (output) {
-		
+
 							if (!out_json) {
 								std::cout << output_labels[4] << output << std::endl;
 							} else {
 								j_level1[json_output_labels[4]] = output;
 							}
 							free(output);
-		
+
 						}
-		
+
 						std::list<security_scan_results_t> ssr_list;
-		
+
 						if (rules) {
-		
+
 							scan_content (
 									c,
 									file_size,
@@ -859,9 +859,9 @@ int main(int argc, char* argv[]) {
 									fs,
 									yara_cb,
 									1);
-							
+
 						} else {
-							
+
 							scan_content (
 									c,
 									file_size,
@@ -870,21 +870,21 @@ int main(int argc, char* argv[]) {
 									fs,
 									yara_cb,
 									1);
-							
+
 						}
-		
+
 						if (!ssr_list.empty()) {
-		
+
 							if (!out_json) {
 								std::cout << std::endl << midline << std::endl;
 							}
-							
+
 							for (std::list<security_scan_results_t>::const_iterator v = ssr_list.begin();
 									v != ssr_list.end();
 									v++) {
-		
+
 								if (!out_json) {
-		
+
 									legacy_output(v->file_scan_result,
 											v->file_scan_type,
 											v->file_signature_md5,
@@ -892,46 +892,46 @@ int main(int argc, char* argv[]) {
 											v->child_file_name,
 											v->file_size
 											);
-		
+
 								} else {
-		
+
 									std::string file_scan_result = v->file_scan_result;
-									
+
 									if (file_scan_result.size() > 1) {
 										j_level1[json_output_labels[10]] = true;
 									}
-									
+
 									// we have hits
 									if (file_scan_result.size()) {
-										
+
 										std::vector<std::string> tokens;
 										std::string delim = meta_delim;
 										delim.append(" ");
 										//tokenize_string (file_scan_result, tokens, meta_delim);
 										tokenize_string (file_scan_result, tokens, delim);
-										
+
 										// we have multiple hits
 										if (tokens.size() > 0) {
-											
+
 											for (auto& it : tokens) {
-												
+
 												std::string pshs_resp = process_scan_hit_str(it,
-														v->file_scan_type, 
+														v->file_scan_type,
 														v->file_signature_md5,
 														v->parent_file_name,
 														v->child_file_name);
-												
+
 												if (pshs_resp.size()) {
-	
+
 													auto jresp = parse_json_string(pshs_resp);
 													if (!jresp.is_null()) {
 														jresp[json_output_labels[10]] = true;
 														jresp[json_output_labels[1]] = v->file_size;
 														j_children.push_back(jresp);
 													}
-													
+
 												} else {
-		
+
 													std::string j_no_hit = process_scan_no_hit(true,
 															it,
 															v->file_scan_type,
@@ -941,37 +941,37 @@ int main(int argc, char* argv[]) {
 															v->file_size
 															);
 													if (j_no_hit.size() > 0) {
-														
+
 														auto jnh = parse_json_string(j_no_hit);
 														if (!jnh.is_null()) {
 															j_children.push_back(jnh);
 														}
-														
+
 													}
-													
+
 												}
-												
+
 											}
-											
+
 										} else { // we have single hit
-											
+
 											std::string pshs_resp = process_scan_hit_str(file_scan_result,
-													v->file_scan_type, 
+													v->file_scan_type,
 													v->file_signature_md5,
 													v->parent_file_name,
 													v->child_file_name);
-											
+
 											if (pshs_resp.size()) {
-												
+
 												auto jresp = parse_json_string(pshs_resp);
 												if (!jresp.is_null()) {
 													jresp[json_output_labels[10]] = true;
 													jresp[json_output_labels[1]] = v->file_size;
 													j_children.push_back(jresp);
 												}
-												
+
 											} else {
-												
+
 												std::string j_no_hit = process_scan_no_hit(true,
 														file_scan_result,
 														v->file_scan_type,
@@ -981,20 +981,20 @@ int main(int argc, char* argv[]) {
 														v->file_size
 														);
 												if (j_no_hit.size() > 0) {
-													
+
 													auto jnh = parse_json_string(j_no_hit);
 													if (!jnh.is_null()) {
 														j_children.push_back(jnh);
 													}
-													
+
 												}
-		
+
 											}
-											
+
 										}
-									
+
 									} else { // no hits just display meta data
-										
+
 										std::string j_no_hit = process_scan_no_hit(false,
 												"",
 												v->file_scan_type,
@@ -1004,67 +1004,67 @@ int main(int argc, char* argv[]) {
 												v->file_size
 												);
 										if (j_no_hit.size() > 0) {
-											
-											//j_children.push_back(json::parse(j_no_hit));										
+
+											//j_children.push_back(json::parse(j_no_hit));
 											auto jnh = parse_json_string(j_no_hit);
 											if (!jnh.is_null()) {
 												j_children.push_back(jnh);
 											}
-											
+
 										}
-										
+
 									}
-		
+
 								}
-		
+
 							}
-		
+
 							if (!out_json) {
 								std::cout << std::endl << omega << std::endl;
 							}
-		
+
 						} else {
-		
+
 							if (!out_json) {
 								std::cout << std::endl << omega << std::endl;
 							}
-		
+
 						}
-					
+
 					}
-	
+
 					delete[] c;
 					fclose(file);
 				}
-	
+
 				//j_level1[json_output_labels[13]] = j_children;
 				if (!j_children.is_null()) {
 					j_level1[json_output_labels[13]] = j_children;
 				}
-				
+
 				if (!j_level1.is_null()) {
 					j_main.push_back(j_level1);
 				}
-				
+
 			}
-	
+
 		} else {
-			
+
 			std::cout << std::endl << "Could not read resource: \"" << target_resource << "\", exiting ..." << std::endl << std::endl;
-		
+
 		}
-		
+
 		if (!j_main.is_null()) {
-			
+
 			if (out_json) {
-		
+
 				if (out_json_pretty_print)
 					std::cout << j_main.dump(4);
 				else
 					std::cout << j_main.dump();
-			
+
 			}
-		
+
 		}
 
 	} catch (nlohmann::detail::type_error & e) {
@@ -1087,4 +1087,3 @@ int main(int argc, char* argv[]) {
 
 	return 0;
 }
-

--- a/main.cpp
+++ b/main.cpp
@@ -499,151 +499,207 @@ int main(int argc, char* argv[]) {
 		std::cout << std::endl << "Problem compiling Yara Ruleset file: \"" << yara_ruleset_file_name << "\", continuing with regular ruleset file ..." << std::endl << std::endl;
 	}
 
-	json j_main;
-
-	if (is_directory(target_resource.c_str())) {
-
-		DIR *dpdf;
-		struct dirent *epdf;
-
-		dpdf = opendir(target_resource.c_str());
-		if (dpdf != NULL) {
-			
-			while (epdf = readdir(dpdf)) {
-
-				json j_level1;
+	
+	try {
+	
+		json j_main;
+	
+		if (is_directory(target_resource.c_str())) {
+	
+			DIR *dpdf;
+			struct dirent *epdf;
+	
+			dpdf = opendir(target_resource.c_str());
+			if (dpdf != NULL) {
 				
-				uint8_t *c;
-				FILE *file = NULL;
-
-				strncpy (fs, target_resource.c_str(), sizeof(fs));
-				fs[sizeof(fs)-1]= '\0'; //fs[strlen(target_resource.c_str())] = '\0';
-				
-				if (epdf->d_name[0] != '.') {
+				while (epdf = readdir(dpdf)) {
+	
+					json j_level1;
 					
-					json j_children;
-
-					strncat (fs, epdf->d_name, strlen(epdf->d_name));
-					fs[strlen(fs)] = '\0';
-
-					if (is_directory(fs)) {
-						// We do not recurse into directories yet
-						continue;
-					}
-
-					if ((file = fopen(fs, "rb")) != NULL) {
-						// Get the size of the file in bytes
-						size_t file_size = get_file_size(fs);
-
-						// Allocate space in the buffer for the whole file
-						c = new uint8_t[file_size];
-						// Read the file in to the buffer
-						size_t dat_read = fread(c, 1, file_size, file);
+					uint8_t *c;
+					FILE *file = NULL;
+	
+					strncpy (fs, target_resource.c_str(), sizeof(fs));
+					fs[sizeof(fs)-1]= '\0'; //fs[strlen(target_resource.c_str())] = '\0';
+					
+					if (epdf->d_name[0] != '.') {
 						
-						if (dat_read == file_size) {
+						json j_children;
 	
-							if (!out_json) {
-								
-								std::cout << std::endl << alpha << std::endl;
-								std::cout << output_labels[8] << yara_ruleset_file_name << std::endl;
-								std::cout << output_labels[0] << fs << std::endl;
-								std::cout << output_labels[1] << file_size << std::endl;
+						strncat (fs, epdf->d_name, strlen(epdf->d_name));
+						fs[strlen(fs)] = '\0';
+	
+						if (is_directory(fs)) {
+							// We do not recurse into directories yet
+							continue;
+						}
+	
+						if ((file = fopen(fs, "rb")) != NULL) {
+							// Get the size of the file in bytes
+							size_t file_size = get_file_size(fs);
+	
+							// Allocate space in the buffer for the whole file
+							c = new uint8_t[file_size];
+							// Read the file in to the buffer
+							size_t dat_read = fread(c, 1, file_size, file);
 							
-							} else {
-	
-								j_level1[json_output_labels[8]] = yara_ruleset_file_name;
-								j_level1[json_output_labels[0]] = fs;
-								j_level1[json_output_labels[1]] = file_size;							
-								
-							}
-	
-							char *output = str_to_md5((const char *)c, file_size);
-							if (output) {
-	
+							if (dat_read == file_size) {
+		
 								if (!out_json) {
-									std::cout << output_labels[4] << output << std::endl;
+									
+									std::cout << std::endl << alpha << std::endl;
+									std::cout << output_labels[8] << yara_ruleset_file_name << std::endl;
+									std::cout << output_labels[0] << fs << std::endl;
+									std::cout << output_labels[1] << file_size << std::endl;
+								
 								} else {
-									j_level1[json_output_labels[4]] = output;
-								}
-								free(output);
-							}
-	
-							std::list<security_scan_results_t> ssr_list;
-	
-							if (rules) {
-	
-								scan_content (
-										c,
-										file_size,
-										rules,
-										&ssr_list,
-										fs,
-										yara_cb,
-										1);
-	
-							} else {
-								
-								scan_content (
-										c,
-										file_size,
-										yara_ruleset_file_name.c_str(),
-										&ssr_list,
-										fs,
-										yara_cb,
-										1);
-								
-							}
-	
-							if (!ssr_list.empty()) {
-	
-								if (!out_json) {
-									std::cout << std::endl << midline << std::endl;
-								}
-								
-								for (std::list<security_scan_results_t>::const_iterator v = ssr_list.begin();
-										v != ssr_list.end();
-										v++) {
+		
+									j_level1[json_output_labels[8]] = yara_ruleset_file_name;
+									j_level1[json_output_labels[0]] = fs;
+									j_level1[json_output_labels[1]] = file_size;							
 									
+								}
+		
+								char *output = str_to_md5((const char *)c, file_size);
+								if (output) {
+		
 									if (!out_json) {
-										
-										legacy_output(v->file_scan_result,
-												v->file_scan_type,
-												v->file_signature_md5,
-												v->parent_file_name,
-												v->child_file_name,
-												v->file_size
-												);
-									
+										std::cout << output_labels[4] << output << std::endl;
 									} else {
+										j_level1[json_output_labels[4]] = output;
+									}
+									free(output);
+								}
+		
+								std::list<security_scan_results_t> ssr_list;
+		
+								if (rules) {
+		
+									scan_content (
+											c,
+											file_size,
+											rules,
+											&ssr_list,
+											fs,
+											yara_cb,
+											1);
+		
+								} else {
+									
+									scan_content (
+											c,
+											file_size,
+											yara_ruleset_file_name.c_str(),
+											&ssr_list,
+											fs,
+											yara_cb,
+											1);
+									
+								}
+		
+								if (!ssr_list.empty()) {
+		
+									if (!out_json) {
+										std::cout << std::endl << midline << std::endl;
+									}
+									
+									for (std::list<security_scan_results_t>::const_iterator v = ssr_list.begin();
+											v != ssr_list.end();
+											v++) {
 										
-										std::string file_scan_result = v->file_scan_result;
-										if (file_scan_result.size() > 1) {
-	
-											j_level1[json_output_labels[10]] = true;
+										if (!out_json) {
 											
-										}
+											legacy_output(v->file_scan_result,
+													v->file_scan_type,
+													v->file_signature_md5,
+													v->parent_file_name,
+													v->child_file_name,
+													v->file_size
+													);
 										
-										std::vector<std::string> tokens;
-										std::string delim = meta_delim;
-										delim.append(" ");
-										tokenize_string (file_scan_result, tokens, delim);
-										
-										// we have hits
-										if (file_scan_result.size()) {
-										
-											// we have multiple hits
-											if (tokens.size() > 0) {
+										} else {
+											
+											std::string file_scan_result = v->file_scan_result;
+											if (file_scan_result.size() > 1) {
+		
+												j_level1[json_output_labels[10]] = true;
 												
-												for (auto& it : tokens) {
+											}
+											
+											std::vector<std::string> tokens;
+											std::string delim = meta_delim;
+											delim.append(" ");
+											tokenize_string (file_scan_result, tokens, delim);
+											
+											// we have hits
+											if (file_scan_result.size()) {
+											
+												// we have multiple hits
+												if (tokens.size() > 0) {
 													
-													std::string pshs_resp = process_scan_hit_str(it,
+													for (auto& it : tokens) {
+														
+														std::string pshs_resp = process_scan_hit_str(it,
+																v->file_scan_type, 
+																v->file_signature_md5,
+																v->parent_file_name,
+																v->child_file_name);
+														
+														if (pshs_resp.size()) {
+	
+															auto jresp = parse_json_string(pshs_resp);
+															if (!jresp.is_null()) {
+																jresp[json_output_labels[10]] = true;
+																jresp[json_output_labels[1]] = v->file_size;
+																j_children.push_back(jresp);
+															}
+															
+														} else {
+															
+															/*
+															 * here we have rule hits with not much
+															 * in the way of meta-data, an example
+															 * of a rule like this:
+															 * 
+															 *     rule is_entropy
+															 *     {
+															 *         condition:
+															 *             math.entropy(0,filesize)>5
+															 *     }
+															 * 
+															 * 
+															 */													
+															std::string j_no_hit = process_scan_no_hit(true,
+																	it,
+																	v->file_scan_type,
+																	v->file_signature_md5,
+																	v->parent_file_name,
+																	v->child_file_name,
+																	v->file_size
+																	);
+															if (j_no_hit.size() > 0) {
+																
+																auto jnh = parse_json_string(j_no_hit);
+																if (!jnh.is_null()) {
+																	j_children.push_back(jnh);
+																}
+																
+															}
+															
+														}
+														
+													}
+													
+												} else { // we have single hit
+													
+													std::string pshs_resp = process_scan_hit_str(file_scan_result,
 															v->file_scan_type, 
 															v->file_signature_md5,
 															v->parent_file_name,
 															v->child_file_name);
 													
 													if (pshs_resp.size()) {
-
+	
 														auto jresp = parse_json_string(pshs_resp);
 														if (!jresp.is_null()) {
 															jresp[json_output_labels[10]] = true;
@@ -652,22 +708,9 @@ int main(int argc, char* argv[]) {
 														}
 														
 													} else {
-														
-														/*
-														 * here we have rule hits with not much
-														 * in the way of meta-data, an example
-														 * of a rule like this:
-														 * 
-														 *     rule is_entropy
-														 *     {
-														 *         condition:
-														 *             math.entropy(0,filesize)>5
-														 *     }
-														 * 
-														 * 
-														 */													
+		
 														std::string j_no_hit = process_scan_no_hit(true,
-																it,
+																file_scan_result,
 																v->file_scan_type,
 																v->file_signature_md5,
 																v->parent_file_name,
@@ -686,251 +729,11 @@ int main(int argc, char* argv[]) {
 													}
 													
 												}
-												
-											} else { // we have single hit
-												
-												std::string pshs_resp = process_scan_hit_str(file_scan_result,
-														v->file_scan_type, 
-														v->file_signature_md5,
-														v->parent_file_name,
-														v->child_file_name);
-												
-												if (pshs_resp.size()) {
-
-													auto jresp = parse_json_string(pshs_resp);
-													if (!jresp.is_null()) {
-														jresp[json_output_labels[10]] = true;
-														jresp[json_output_labels[1]] = v->file_size;
-														j_children.push_back(jresp);
-													}
-													
-												} else {
-	
-													std::string j_no_hit = process_scan_no_hit(true,
-															file_scan_result,
-															v->file_scan_type,
-															v->file_signature_md5,
-															v->parent_file_name,
-															v->child_file_name,
-															v->file_size
-															);
-													if (j_no_hit.size() > 0) {
-														
-														auto jnh = parse_json_string(j_no_hit);
-														if (!jnh.is_null()) {
-															j_children.push_back(jnh);
-														}
-														
-													}
-													
-												}
-												
-											}
-										
-										} else { // no hits just display meta data
-	
-											std::string j_no_hit = process_scan_no_hit(false,
-													"",
-													v->file_scan_type,
-													v->file_signature_md5,
-													v->parent_file_name,
-													v->child_file_name,
-													v->file_size
-													);
-											if (j_no_hit.size() > 0) {
-												
-												auto jnh = parse_json_string(j_no_hit);
-												if (!jnh.is_null()) {
-													j_children.push_back(jnh);
-												}
-												
-											}
 											
-										}
-										
-									}
-									
-								}
-								
-								if (!out_json) {
-									std::cout << std::endl << omega << std::endl;
-								}
-								
-							} else {
-								
-								if (!out_json) {
-									std::cout << std::endl << omega << std::endl;
-								}
-								
-							}
-						
-						}
-
-						delete[] c;
-						fclose(file);
-
-					}
-					
-					if (!j_children.is_null()) {
-						j_level1[json_output_labels[13]] = j_children;
-					}
-				
-				} else {
-					
-					continue;
-					
-				}
-
-				if (!j_level1.is_null()) {
-					j_main.push_back(j_level1);
-				}
-
-			}
-
-			closedir(dpdf);
-
-		}
+											} else { // no hits just display meta data
 		
-	} else if (does_this_file_exist(target_resource.c_str())) {
-
-		uint8_t *c;
-		FILE *file = NULL;
-		strncpy (fs, target_resource.c_str(), sizeof(fs));
-		fs[sizeof(fs)-1]= '\0'; //fs[strlen(target_resource.c_str())] = '\0';
-
-		
-		if (fs[0] != '.') {
-
-			json j_level1;
-			json j_children;
-			
-			if ((file = fopen(fs, "rb")) != NULL) {
-				
-				// Get the size of the file in bytes
-				size_t file_size = get_file_size(fs);
-
-				// Allocate space in the buffer for the whole file
-				c = new uint8_t[file_size];
-
-				// Read the file in to the buffer
-				//fread(c, file_size, 1, file);
-				size_t dat_read = fread(c, 1, file_size, file);
-				
-				if (dat_read == file_size) {
-	
-					if (!out_json) {
-	
-						std::cout << std::endl << alpha << std::endl;
-						std::cout << output_labels[0] << fs << std::endl;
-						std::cout << output_labels[1] << file_size << std::endl;
-	
-					} else {
-	
-						j_level1[json_output_labels[8]] = yara_ruleset_file_name;
-						j_level1[json_output_labels[0]] = fs;
-						j_level1[json_output_labels[1]] = file_size;
-	
-					}
-	
-					char *output = str_to_md5((const char *)c, file_size);
-					if (output) {
-	
-						if (!out_json) {
-							std::cout << output_labels[4] << output << std::endl;
-						} else {
-							j_level1[json_output_labels[4]] = output;
-						}
-						free(output);
-	
-					}
-	
-					std::list<security_scan_results_t> ssr_list;
-	
-					if (rules) {
-	
-						scan_content (
-								c,
-								file_size,
-								rules,
-								&ssr_list,
-								fs,
-								yara_cb,
-								1);
-						
-					} else {
-						
-						scan_content (
-								c,
-								file_size,
-								yara_ruleset_file_name.c_str(),
-								&ssr_list,
-								fs,
-								yara_cb,
-								1);
-						
-					}
-	
-					if (!ssr_list.empty()) {
-	
-						if (!out_json) {
-							std::cout << std::endl << midline << std::endl;
-						}
-						
-						for (std::list<security_scan_results_t>::const_iterator v = ssr_list.begin();
-								v != ssr_list.end();
-								v++) {
-	
-							if (!out_json) {
-	
-								legacy_output(v->file_scan_result,
-										v->file_scan_type,
-										v->file_signature_md5,
-										v->parent_file_name,
-										v->child_file_name,
-										v->file_size
-										);
-	
-							} else {
-	
-								std::string file_scan_result = v->file_scan_result;
-								
-								if (file_scan_result.size() > 1) {
-									j_level1[json_output_labels[10]] = true;
-								}
-								
-								// we have hits
-								if (file_scan_result.size()) {
-									
-									std::vector<std::string> tokens;
-									std::string delim = meta_delim;
-									delim.append(" ");
-									//tokenize_string (file_scan_result, tokens, meta_delim);
-									tokenize_string (file_scan_result, tokens, delim);
-									
-									// we have multiple hits
-									if (tokens.size() > 0) {
-										
-										for (auto& it : tokens) {
-											
-											std::string pshs_resp = process_scan_hit_str(it,
-													v->file_scan_type, 
-													v->file_signature_md5,
-													v->parent_file_name,
-													v->child_file_name);
-											
-											if (pshs_resp.size()) {
-
-												auto jresp = parse_json_string(pshs_resp);
-												if (!jresp.is_null()) {
-													jresp[json_output_labels[10]] = true;
-													jresp[json_output_labels[1]] = v->file_size;
-													j_children.push_back(jresp);
-												}
-												
-											} else {
-	
-												std::string j_no_hit = process_scan_no_hit(true,
-														it,
+												std::string j_no_hit = process_scan_no_hit(false,
+														"",
 														v->file_scan_type,
 														v->file_signature_md5,
 														v->parent_file_name,
@@ -950,118 +753,332 @@ int main(int argc, char* argv[]) {
 											
 										}
 										
-									} else { // we have single hit
-										
-										std::string pshs_resp = process_scan_hit_str(file_scan_result,
-												v->file_scan_type, 
-												v->file_signature_md5,
-												v->parent_file_name,
-												v->child_file_name);
-										
-										if (pshs_resp.size()) {
-											
-											auto jresp = parse_json_string(pshs_resp);
-											if (!jresp.is_null()) {
-												jresp[json_output_labels[10]] = true;
-												jresp[json_output_labels[1]] = v->file_size;
-												j_children.push_back(jresp);
-											}
-											
-										} else {
-											
-											std::string j_no_hit = process_scan_no_hit(true,
-													file_scan_result,
-													v->file_scan_type,
-													v->file_signature_md5,
-													v->parent_file_name,
-													v->child_file_name,
-													v->file_size
-													);
-											if (j_no_hit.size() > 0) {
-												
-												auto jnh = parse_json_string(j_no_hit);
-												if (!jnh.is_null()) {
-													j_children.push_back(jnh);
-												}
-												
-											}
-	
-										}
-										
 									}
-								
-								} else { // no hits just display meta data
 									
-									std::string j_no_hit = process_scan_no_hit(false,
-											"",
+									if (!out_json) {
+										std::cout << std::endl << omega << std::endl;
+									}
+									
+								} else {
+									
+									if (!out_json) {
+										std::cout << std::endl << omega << std::endl;
+									}
+									
+								}
+							
+							}
+	
+							delete[] c;
+							fclose(file);
+	
+						}
+						
+						if (!j_children.is_null()) {
+							j_level1[json_output_labels[13]] = j_children;
+						}
+					
+					} else {
+						
+						continue;
+						
+					}
+	
+					if (!j_level1.is_null()) {
+						j_main.push_back(j_level1);
+					}
+	
+				}
+	
+				closedir(dpdf);
+	
+			}
+			
+		} else if (does_this_file_exist(target_resource.c_str())) {
+	
+			uint8_t *c;
+			FILE *file = NULL;
+			strncpy (fs, target_resource.c_str(), sizeof(fs));
+			fs[sizeof(fs)-1]= '\0'; //fs[strlen(target_resource.c_str())] = '\0';
+	
+			
+			if (fs[0] != '.') {
+	
+				json j_level1;
+				json j_children;
+				
+				if ((file = fopen(fs, "rb")) != NULL) {
+					
+					// Get the size of the file in bytes
+					size_t file_size = get_file_size(fs);
+	
+					// Allocate space in the buffer for the whole file
+					c = new uint8_t[file_size];
+	
+					// Read the file in to the buffer
+					//fread(c, file_size, 1, file);
+					size_t dat_read = fread(c, 1, file_size, file);
+					
+					if (dat_read == file_size) {
+		
+						if (!out_json) {
+		
+							std::cout << std::endl << alpha << std::endl;
+							std::cout << output_labels[0] << fs << std::endl;
+							std::cout << output_labels[1] << file_size << std::endl;
+		
+						} else {
+		
+							j_level1[json_output_labels[8]] = yara_ruleset_file_name;
+							j_level1[json_output_labels[0]] = fs;
+							j_level1[json_output_labels[1]] = file_size;
+		
+						}
+		
+						char *output = str_to_md5((const char *)c, file_size);
+						if (output) {
+		
+							if (!out_json) {
+								std::cout << output_labels[4] << output << std::endl;
+							} else {
+								j_level1[json_output_labels[4]] = output;
+							}
+							free(output);
+		
+						}
+		
+						std::list<security_scan_results_t> ssr_list;
+		
+						if (rules) {
+		
+							scan_content (
+									c,
+									file_size,
+									rules,
+									&ssr_list,
+									fs,
+									yara_cb,
+									1);
+							
+						} else {
+							
+							scan_content (
+									c,
+									file_size,
+									yara_ruleset_file_name.c_str(),
+									&ssr_list,
+									fs,
+									yara_cb,
+									1);
+							
+						}
+		
+						if (!ssr_list.empty()) {
+		
+							if (!out_json) {
+								std::cout << std::endl << midline << std::endl;
+							}
+							
+							for (std::list<security_scan_results_t>::const_iterator v = ssr_list.begin();
+									v != ssr_list.end();
+									v++) {
+		
+								if (!out_json) {
+		
+									legacy_output(v->file_scan_result,
 											v->file_scan_type,
 											v->file_signature_md5,
 											v->parent_file_name,
 											v->child_file_name,
 											v->file_size
 											);
-									if (j_no_hit.size() > 0) {
+		
+								} else {
+		
+									std::string file_scan_result = v->file_scan_result;
+									
+									if (file_scan_result.size() > 1) {
+										j_level1[json_output_labels[10]] = true;
+									}
+									
+									// we have hits
+									if (file_scan_result.size()) {
 										
-										//j_children.push_back(json::parse(j_no_hit));										
-										auto jnh = parse_json_string(j_no_hit);
-										if (!jnh.is_null()) {
-											j_children.push_back(jnh);
+										std::vector<std::string> tokens;
+										std::string delim = meta_delim;
+										delim.append(" ");
+										//tokenize_string (file_scan_result, tokens, meta_delim);
+										tokenize_string (file_scan_result, tokens, delim);
+										
+										// we have multiple hits
+										if (tokens.size() > 0) {
+											
+											for (auto& it : tokens) {
+												
+												std::string pshs_resp = process_scan_hit_str(it,
+														v->file_scan_type, 
+														v->file_signature_md5,
+														v->parent_file_name,
+														v->child_file_name);
+												
+												if (pshs_resp.size()) {
+	
+													auto jresp = parse_json_string(pshs_resp);
+													if (!jresp.is_null()) {
+														jresp[json_output_labels[10]] = true;
+														jresp[json_output_labels[1]] = v->file_size;
+														j_children.push_back(jresp);
+													}
+													
+												} else {
+		
+													std::string j_no_hit = process_scan_no_hit(true,
+															it,
+															v->file_scan_type,
+															v->file_signature_md5,
+															v->parent_file_name,
+															v->child_file_name,
+															v->file_size
+															);
+													if (j_no_hit.size() > 0) {
+														
+														auto jnh = parse_json_string(j_no_hit);
+														if (!jnh.is_null()) {
+															j_children.push_back(jnh);
+														}
+														
+													}
+													
+												}
+												
+											}
+											
+										} else { // we have single hit
+											
+											std::string pshs_resp = process_scan_hit_str(file_scan_result,
+													v->file_scan_type, 
+													v->file_signature_md5,
+													v->parent_file_name,
+													v->child_file_name);
+											
+											if (pshs_resp.size()) {
+												
+												auto jresp = parse_json_string(pshs_resp);
+												if (!jresp.is_null()) {
+													jresp[json_output_labels[10]] = true;
+													jresp[json_output_labels[1]] = v->file_size;
+													j_children.push_back(jresp);
+												}
+												
+											} else {
+												
+												std::string j_no_hit = process_scan_no_hit(true,
+														file_scan_result,
+														v->file_scan_type,
+														v->file_signature_md5,
+														v->parent_file_name,
+														v->child_file_name,
+														v->file_size
+														);
+												if (j_no_hit.size() > 0) {
+													
+													auto jnh = parse_json_string(j_no_hit);
+													if (!jnh.is_null()) {
+														j_children.push_back(jnh);
+													}
+													
+												}
+		
+											}
+											
+										}
+									
+									} else { // no hits just display meta data
+										
+										std::string j_no_hit = process_scan_no_hit(false,
+												"",
+												v->file_scan_type,
+												v->file_signature_md5,
+												v->parent_file_name,
+												v->child_file_name,
+												v->file_size
+												);
+										if (j_no_hit.size() > 0) {
+											
+											//j_children.push_back(json::parse(j_no_hit));										
+											auto jnh = parse_json_string(j_no_hit);
+											if (!jnh.is_null()) {
+												j_children.push_back(jnh);
+											}
+											
 										}
 										
 									}
-									
+		
 								}
-	
+		
 							}
-	
+		
+							if (!out_json) {
+								std::cout << std::endl << omega << std::endl;
+							}
+		
+						} else {
+		
+							if (!out_json) {
+								std::cout << std::endl << omega << std::endl;
+							}
+		
 						}
-	
-						if (!out_json) {
-							std::cout << std::endl << omega << std::endl;
-						}
-	
-					} else {
-	
-						if (!out_json) {
-							std::cout << std::endl << omega << std::endl;
-						}
-	
+					
 					}
-				
+	
+					delete[] c;
+					fclose(file);
 				}
-
-				delete[] c;
-				fclose(file);
+	
+				//j_level1[json_output_labels[13]] = j_children;
+				if (!j_children.is_null()) {
+					j_level1[json_output_labels[13]] = j_children;
+				}
+				
+				if (!j_level1.is_null()) {
+					j_main.push_back(j_level1);
+				}
+				
 			}
-
-			//j_level1[json_output_labels[13]] = j_children;
-			if (!j_children.is_null()) {
-				j_level1[json_output_labels[13]] = j_children;
-			}
+	
+		} else {
 			
-			if (!j_level1.is_null()) {
-				j_main.push_back(j_level1);
-			}
-			
-		}
-
-	} else {
-		
-		std::cout << std::endl << "Could not read resource: \"" << target_resource << "\", exiting ..." << std::endl << std::endl;
-	
-	}
-	
-	if (!j_main.is_null()) {
-		
-		if (out_json) {
-	
-			if (out_json_pretty_print)
-				std::cout << j_main.dump(4);
-			else
-				std::cout << j_main.dump();
+			std::cout << std::endl << "Could not read resource: \"" << target_resource << "\", exiting ..." << std::endl << std::endl;
 		
 		}
-	
+		
+		if (!j_main.is_null()) {
+			
+			if (out_json) {
+		
+				if (out_json_pretty_print)
+					std::cout << j_main.dump(4);
+				else
+					std::cout << j_main.dump();
+			
+			}
+		
+		}
+
+	} catch (nlohmann::detail::type_error & e) {
+		std::cout << json_type_error << " : " << e.what() << std::endl;
+	} catch (nlohmann::detail::parse_error const& e) {
+		std::cout << json_parse_error << " : " << e.what() << std::endl;
+	} catch (nlohmann::detail::invalid_iterator const& e) {
+		std::cout << json_invalid_iterator_error << " : " << e.what() << std::endl;
+	} catch (nlohmann::detail::out_of_range const& e) {
+		std::cout << json_out_of_range_error << " : " << e.what() << std::endl;
+	} catch (nlohmann::detail::other_error const& e) {
+		std::cout << json_other_error << " : " << e.what() << std::endl;
+	} catch (nlohmann::detail::exception const& e) {
+		std::cout << json_exception << " : " << e.what() << std::endl;
 	}
 
 	if (rules != NULL) {

--- a/wrapper.cpp
+++ b/wrapper.cpp
@@ -3,21 +3,21 @@
  * YEXTEND: Help for YARA users.
  * This file is part of yextend.
  *
- * Copyright (c) 2014-2017, Bayshore Networks, Inc.
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
  * following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
  * following disclaimer in the documentation and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
  * products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
@@ -37,11 +37,11 @@ using namespace std;
 
 #include <sys/stat.h>
 
-/* 
+/*
  * The following functions implement the high-level API to our content-inspection facilities.
  * High-level applications will want to call these entry points rather than the underlying
  * C++ objects.
- *    
+ *
  */
 
 /****************
@@ -251,5 +251,3 @@ bool is_type_bzip2 (int ix)
 {
 	return is_bzip2 (ix);
 }
-
-

--- a/wrapper.h
+++ b/wrapper.h
@@ -3,21 +3,21 @@
  * YEXTEND: Help for YARA users.
  * This file is part of yextend.
  *
- * Copyright (c) 2014-2017, Bayshore Networks, Inc.
+ * Copyright (c) 2014-2018, Bayshore Networks, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that
  * the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
  * following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
  * following disclaimer in the documentation and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
  * products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
  * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
@@ -62,7 +62,7 @@ extern "C" {
     bool is_type_7zip(int);
     bool is_type_executable(int);
     bool is_type_bzip2(int);
-    
+
     int get_file_object_type(const uint8_t *);
 }
 


### PR DESCRIPTION
This branch solves the following cases presented by putty.pdf file:
- Plain text streams (not encoded).
- Dictionaries begining with LF or spaces.